### PR TITLE
Fix integer overflow in tech_bonus calculation

### DIFF
--- a/src/lincity/modules/organic_farm.h
+++ b/src/lincity/modules/organic_farm.h
@@ -78,7 +78,7 @@ public:
         init_resources();
         this->tech = tech_level;
         setMemberSaved(&this->tech, "tech");
-        this->tech_bonus = (tech_level * ORGANIC_FARM_FOOD_OUTPUT) / MAX_TECH_LEVEL;
+        this->tech_bonus = int( ((long long int)tech_level * ORGANIC_FARM_FOOD_OUTPUT) / MAX_TECH_LEVEL );
         setMemberSaved(&this->tech_bonus, "tech_bonus");
         this->crop_rotation_key = (rand() % 4) + 1;
         this->month_stagger = rand() % 100;


### PR DESCRIPTION
In:
this->tech_bonus = (tech_level * ORGANIC_FARM_FOOD_OUTPUT) / MAX_TECH_LEVEL;
an overflow would occur. my tech level was ~ 390 (3'900'000 as stored in the int) while ORGANIC_FARM_FOOD_OUTPUT is 550.  which results in a number of 2'145'000'000 , which is unfortunately somewhat larger than an integer can represent. The number would therefore overflow and become something extreme negative. Some other code would then set the foodprod to 30 in organic_farm.cpp if it is lower than that , which explains why it was at least 30.
Casting tech_level to a long long int causes the calculation to be done with 64 bit integers and fixes the problem. After Dividing by MAX_TECH_LEVEL (1000000) the number is again safe to be stored as int.
funnily a farm without power would output ~135 which is the default and independent of the tech level , but with power output has gone down to 30 :D