### PR TITLE
Tell the compiler to use C++14

### DIFF
--- a/Jamrules
+++ b/Jamrules
@@ -11,6 +11,8 @@ if ! $(JAMCONFIG_READ)
   EXIT "Couldn't find config. Please run 'configure' first." ;
 }
 
+CXXFLAGS += -std=c++14 ;
+
 if $(USE_STLPORT_DEBUG)
 {
   CXXFLAGS += -I/usr/include/stlport ;


### PR DESCRIPTION
Clang does not build against C++14 by default. Therefore we should explicitly tell the compiler which version of C++ standard to use.