### PR TITLE
ax_check_gl.m4: Also check against -lOpenGL

### DIFF
--- a/mk/autoconf/ax_check_gl.m4
+++ b/mk/autoconf/ax_check_gl.m4
@@ -60,7 +60,7 @@ else
   CPPFLAGS="${GL_CFLAGS} ${CPPFLAGS}"
   ax_save_LIBS="${LIBS}"
   LIBS=""
-  ax_check_libs="-lopengl32 -lGL"
+  ax_check_libs="-lopengl32 -lGL -lOpenGL"
   for ax_lib in ${ax_check_libs}; do
     if test X$ax_compiler_ms = Xyes; then
       ax_try_lib=`echo $ax_lib | sed -e 's/^-l//' -e 's/$/.lib/'`


### PR DESCRIPTION
This allows lincity-ng to compile on wayland without libX11.

Note: This patch also works on lincity-ng 2.5-beta