### PR TITLE
Fix errors on msys2

### DIFF
--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "lincity/modules/all_modules.h"
 #include "lincity/engine.h"
 #include "lincity/lin-city.h"
+#include "lincity/fileutil.h"
 
 #include "Mps.hpp"
 #include "MapEdit.hpp"
@@ -375,7 +376,7 @@ void GameView::show( MapPoint map , bool redraw /* = true */ )
 
 Texture* GameView::readTexture(const std::string& filename)
 {
-    const auto dirsep = "/";
+    const auto dirsep = physfs_indep_dirsep;
     std::string nfilename = std::string("images") + dirsep
     + std::string("tiles") + dirsep + filename;
     Texture* currentTexture;
@@ -394,7 +395,7 @@ Texture* GameView::readTexture(const std::string& filename)
  */
 SDL_Surface* GameView::readImage(const std::string& filename)
 {
-    const auto dirsep = "/";
+    const auto dirsep = physfs_indep_dirsep;
 
     //std::string nfilename;
     //nfilename = std::string("images") + dirsep + std::string("tiles") + dirsep + filename;
@@ -433,7 +434,7 @@ SDL_Surface* GameView::readImage(const std::string& filename)
 
 void GameView::preReadImages(void)
 {
-    const auto dirsep = "/";
+    const auto dirsep = physfs_indep_dirsep;
 
     std::ostringstream os;
     os << "images" << dirsep << "tiles" << dirsep << "images.xml";

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -375,7 +375,7 @@ void GameView::show( MapPoint map , bool redraw /* = true */ )
 
 Texture* GameView::readTexture(const std::string& filename)
 {
-    std::string dirsep = PHYSFS_getDirSeparator();
+    const auto dirsep = "/";
     std::string nfilename = std::string("images") + dirsep
     + std::string("tiles") + dirsep + filename;
     Texture* currentTexture;
@@ -394,7 +394,7 @@ Texture* GameView::readTexture(const std::string& filename)
  */
 SDL_Surface* GameView::readImage(const std::string& filename)
 {
-    std::string dirsep = PHYSFS_getDirSeparator();
+    const auto dirsep = "/";
 
     //std::string nfilename;
     //nfilename = std::string("images") + dirsep + std::string("tiles") + dirsep + filename;
@@ -433,7 +433,7 @@ SDL_Surface* GameView::readImage(const std::string& filename)
 
 void GameView::preReadImages(void)
 {
-    std::string dirsep = PHYSFS_getDirSeparator();
+    const auto dirsep = "/";
 
     std::ostringstream os;
     os << "images" << dirsep << "tiles" << dirsep << "images.xml";

--- a/src/lincity-ng/MainMenu.cpp
+++ b/src/lincity-ng/MainMenu.cpp
@@ -853,7 +853,11 @@ MainMenu::optionsBackButtonClicked(Button* )
     }
     else if( currentLanguage != getConfig()->language )
     {
+#if defined (WIN32)
+        _putenv_s("LINCITY_LANG", "");
+#else
         unsetenv("LINCITY_LANG");
+#endif
         quitState = RESTART;
         running = false;
     }

--- a/src/lincity-ng/Sound.cpp
+++ b/src/lincity-ng/Sound.cpp
@@ -35,6 +35,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Config.hpp"
 #include "lincity/engglobs.h"
 #include "lincity/modules/all_modules.h"
+#include "lincity/fileutil.h"
 
 Sound* soundPtr = 0;
 
@@ -54,10 +55,7 @@ Sound::soundThread(void* ptr)
 void
 Sound::loadWaves() {
     //Load Waves
-
-    // Don't use PHYSFS_getDirSeparator().
-    // PhysicsFS uses "platform-independent notation" when opening a file.
-    const auto dirsep = "/";
+    const auto dirsep = physfs_indep_dirsep;
     std::string directory = "sounds";
     directory += dirsep;
     std::string xmlfile = directory + "sounds.xml";
@@ -149,7 +147,7 @@ void Sound::loadMusicTheme() {
 
     //TODO there should be a music directory in
     // LINCITY_HOME
-    const std::string dirsep = "/";
+    const std::string dirsep = physfs_indep_dirsep;
     std::string musicDir = "music" + dirsep;
     //Reset track counter:
     totalTracks=0;

--- a/src/lincity-ng/Sound.cpp
+++ b/src/lincity-ng/Sound.cpp
@@ -54,7 +54,10 @@ Sound::soundThread(void* ptr)
 void
 Sound::loadWaves() {
     //Load Waves
-    std::string dirsep = PHYSFS_getDirSeparator();
+
+    // Don't use PHYSFS_getDirSeparator().
+    // PhysicsFS uses "platform-independent notation" when opening a file.
+    const auto dirsep = "/";
     std::string directory = "sounds";
     directory += dirsep;
     std::string xmlfile = directory + "sounds.xml";
@@ -146,7 +149,7 @@ void Sound::loadMusicTheme() {
 
     //TODO there should be a music directory in
     // LINCITY_HOME
-    std::string dirsep = PHYSFS_getDirSeparator();
+    const std::string dirsep = "/";
     std::string musicDir = "music" + dirsep;
     //Reset track counter:
     totalTracks=0;

--- a/src/lincity-ng/main.cpp
+++ b/src/lincity-ng/main.cpp
@@ -447,7 +447,11 @@ int main(int argc, char** argv)
         initPhysfs(argv[0]);
 
         if( getConfig()->language != "autodetect" ){
+#if defined (WIN32)
+            _putenv_s("LINCITY_LANG", getConfig()->language.c_str());
+#else
             setenv("LINCITY_LANG", getConfig()->language.c_str(), false);
+#endif
         }
         dictionaryManager = new tinygettext::DictionaryManager();
         dictionaryManager->set_charset("UTF-8");

--- a/src/lincity/fileutil.cpp
+++ b/src/lincity/fileutil.cpp
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <stdarg.h>             /* XXX: GCS FIX: What does configure need to know? */
 #include <string.h>
+#include <string>
 #include <physfs.h>
 #include "engglobs.h"
 #include "gui_interface/screen_interface.h"
@@ -27,7 +28,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#ifdef _MSC_VER
+#ifdef WIN32
 #include <direct.h>
 #include <io.h>
 #endif
@@ -180,7 +181,7 @@ void find_libdir(void)
 {
     const char searchfile[] = "Colour.pal";
     /* default_dir will be something like "C:\\LINCITY1.11" */
-    const char default_dir[] = "C:\\LINCITY" PACKAGE_VERSION;
+    const auto default_dir = std::string("C:\\LINCITY") + PACKAGE_VERSION;
 //    const char default_dir[] = "D:\\LINCITY"; /* For GCS's use */
 
     /* Check 1: environment variable */
@@ -192,8 +193,8 @@ void find_libdir(void)
     }
 
     /* Check 2: default location */
-    if ((_access(default_dir, 0)) != -1) {
-        strcpy(LIBDIR, default_dir);
+    if ((_access(default_dir.c_str(), 0)) != -1) {
+        strcpy(LIBDIR, default_dir.c_str());
         return;
     }
 

--- a/src/lincity/fileutil.h
+++ b/src/lincity/fileutil.h
@@ -51,6 +51,16 @@ void save_lincityrc(void);
 
 void debug_printf(char *fmt, ...);
 
+//Use physfs_indep_dirsep when making a path passed to PHYSFS_openRead.
+//PHYSFS_getDirSeparator() returns "\\" on windows,
+//but passing a path contains "\\" to PHYSFS_openRead cause error.
+//Because PhysicsFS uses "platform-independent notation" when opening a file.
+//Platform-dependent notation is still used when setting up write directory and search path.
+//
+//Read PhysicsFS documentation for more details.
+//https://icculus.org/physfs/docs/html/
+const auto physfs_indep_dirsep = "/";
+
 #endif /* __fileutil_h__ */
 
 /** @file lincity/fileutil.h */


### PR DESCRIPTION
I tried to build lincity-ng using mingw-w64-x86_64-gcc on [msys2](https://www.msys2.org) on Windows, but I got compile errors and runtime errors.
I used CMake using vorot93/cmake branch because ftjam didn't worked well.

It seems `setenv` and `unsetenv` are not standard C function and not defined on Windows.

According to PhysicsFS's document, when opening a file, you specify it like it was on a Unix filesystem.
https://www.icculus.org/physfs/docs/html/
`PHYSFS_getDirSeparator()` returns `"\"` on windows, but passing a path using `"\"` to `PHYSFS_openRead` cause runtime error.
