### PR TITLE
Fix compile error in release build

### DIFF
--- a/src/lincity-ng/Debug.hpp
+++ b/src/lincity-ng/Debug.hpp
@@ -94,6 +94,14 @@ T*checked_cast(Y *x)
   return t;
 }
 
+#else
+
+template<class T,class Y>
+T*checked_cast(Y *x)
+{
+  return dynamic_cast<T*>(x);
+}
+
 #endif
 
 #endif


### PR DESCRIPTION
I got compile error when I tried to build lincity-ng in release build.

`src/lincity-ng/Debug.hpp` defines some macros and functions for debuging.
But they are not defined in release build because `NDEBUG` is defined and cause compile error.

macros and classes defined in Debug.hpp are not used and defining only `checked_cast` fixed the compile error.
