### PR TITLE
Fix warning and compile error in C++20

### DIFF
--- a/src/lincity/lintypes.h
+++ b/src/lincity/lintypes.h
@@ -283,7 +283,7 @@ template <typename ConstructionClass>
 class RegisteredConstruction: public Construction, public Counted<ConstructionClass>
 {
 public:
-    RegisteredConstruction<ConstructionClass>( int x, int y)
+    RegisteredConstruction( int x, int y)
     {
         //this->type = 0;//safe default
         this->soundGroup = 0;//to be set by init_resources()
@@ -299,7 +299,7 @@ public:
         partners.clear();
 #endif
     }
-    ~RegisteredConstruction<ConstructionClass>(){}
+    ~RegisteredConstruction(){}
 };
 
 class GraphicsInfo

--- a/src/tinygettext/findlocale.cpp
+++ b/src/tinygettext/findlocale.cpp
@@ -182,7 +182,7 @@ canonise_fl(FL_Locale *l) {
 #define RML(pn,sn) MAKELANGID(LANG_##pn, SUBLANG_##sn)
 typedef struct {
   LANGID id;
-  char*  code;
+  const char*  code;
 } IDToCode;
 static const IDToCode both_to_code[] = {
   {ML(ENGLISH,US),           "en_US.ISO_8859-1"},


### PR DESCRIPTION
I tried to build lincity-ng with g++ with -std=gnu++20 option and I got compile error in `class RegisteredConstruction` in src/lincity/lintypes.h.
It seems that class uses template incorrectly.
It also fix `warning: ISO C++ forbids converting a string constant to 'char*'`.
