### PR TITLE
anchor gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,18 @@
 # Build Files
-Jamconfig
-Jamconfig.in
-aclocal.m4
-autom4te.cache/
-build/
-config.h
-config.h.in
-config.log
-config.status
-configure
-data/locale/gui/messages.pot
-data/locale/messages.pot
-lincity-ng
-xmlgettext
+/Jamconfig
+/Jamconfig.in
+/aclocal.m4
+/autom4te.cache/
+/build/
+/config.h
+/config.h.in
+/config.log
+/config.status
+/configure
+/data/locale/gui/messages.pot
+/data/locale/messages.pot
+/lincity-ng
+/xmlgettext
 
 # Temporary Files
-.*.swp
+/.*.swp


### PR DESCRIPTION
This anchors the gitignore patterns to the project root so that files are not unintentionally ignored.

Fixes #62.