### PR TITLE
Mouse gesture upgrades

### DIFF
--- a/README
+++ b/README
@@ -157,6 +157,7 @@ use shift + direction to scroll faster
  h  to hide high buildings. Press h again to show them.
  v  to cycle through MiniMap-overlay modes
  b  toggle between current tool and bulldoze mode 
+ g  toggle between right click showing building or tile info
  F1 Help
  
  F12 quick save

--- a/README
+++ b/README
@@ -114,13 +114,12 @@ any:
  Click on Minimap shows the selected Area on mainscreen.
 
 right:
- Drag mainscreen with right mousebutton.
- right click on mainscreen centers to tile under cursor.
+ right click on mainscreen to show info on building under cursor.
  select tool from menu root
  show help on tool
 
 middle:
- middle click on mainscreen to show information about area under cursor.
+ pan map on mainscreen.
 
 left:
  Perform action depending on selected tool. Bulldoze, show Information,
@@ -175,4 +174,3 @@ You can contact us at the lincity-ng-devel mailinglist:
 or you might be able to catch us in irc at irc.freenode.net #lincity.
 
 Visit our homepage: https://github.com/lincity-ng/lincity-ng
-

--- a/src/gui/Event.cpp
+++ b/src/gui/Event.cpp
@@ -52,6 +52,18 @@ Event::Event(SDL_Event& event)
             type = MOUSEWHEEL;
             scrolly = event.wheel.y;
             break;
+        case SDL_WINDOWEVENT:
+            switch(event.window.event) {
+            case SDL_WINDOWEVENT_ENTER:
+                type = WINDOWENTER;
+                break;
+            case SDL_WINDOWEVENT_LEAVE:
+                type = WINDOWLEAVE;
+                break;
+            default:
+                type = WINDOWOTHER;
+            }
+            break;
         default:
             assert(false);
     }
@@ -63,4 +75,3 @@ Event::Event(float _elapsedTime)
 }
 
 /** @file gui/Event.cpp */
-

--- a/src/gui/Event.hpp
+++ b/src/gui/Event.hpp
@@ -48,6 +48,12 @@ public:
         MOUSEBUTTONUP,
         /// a mouse wheel has been turned
         MOUSEWHEEL,
+        /// window gained mouse focus
+        WINDOWENTER,
+        /// window lost mouse focus
+        WINDOWLEAVE,
+        /// other window event
+        WINDOWOTHER,
     };
     /// Create an update Event
     Event(float elapsedTime);
@@ -78,4 +84,3 @@ public:
 
 
 /** @file gui/Event.hpp */
-

--- a/src/lincity-ng/Game.cpp
+++ b/src/lincity-ng/Game.cpp
@@ -175,11 +175,18 @@ Game::run()
         while(SDL_PollEvent(&event)) {
             switch(event.type) {
                 case SDL_WINDOWEVENT:
-                    if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
+                    switch(event.window.event) {
+                    case SDL_WINDOWEVENT_SIZE_CHANGED:
                         videoSizeChanged(event.window.data1, event.window.data2);
                         gui->resize(event.window.data1, event.window.data2);
                         getConfig()->videoX = event.window.data1;
                         getConfig()->videoY = event.window.data2;
+                        break;
+                    case SDL_WINDOWEVENT_ENTER:
+                    case SDL_WINDOWEVENT_LEAVE:
+                        Event gui_event(event);
+                        gui->event(gui_event);
+                        break;
                     }
                     break;
                 case SDL_KEYUP: {
@@ -311,4 +318,3 @@ Game::run()
 }
 
 /** @file lincity-ng/Game.cpp */
-

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -617,7 +617,7 @@ void GameView::event(const Event& event)
                 // this was most probably a SDL_WarpMouse
                 if(event.mousepos == dragStart)
                     break;
-                viewport += event.mousemove;
+                viewport -= event.mousemove;
                 setDirty();
                 break;
             }
@@ -630,8 +630,9 @@ void GameView::event(const Event& event)
             if( !dragging && rightButtonDown ) {
                 dragging = true;
                 dragStart = event.mousepos;
-                SDL_ShowCursor( SDL_DISABLE );
-                dragStartTime = SDL_GetTicks();
+                // This hand has one finger up. I couldn't find the closed hand.
+                SDL_SetCursor(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND));
+                dragStartTime = SDL_GetTicks(); // Is this unused???
             }
             MapPoint tile = getTile(event.mousepos);
             if( !roadDragging && leftButtonDown && ( cursorSize == 1 ) &&
@@ -672,7 +673,7 @@ void GameView::event(const Event& event)
             if(!event.inside) {
                 break;
             }
-            if( event.mousebutton == SDL_BUTTON_RIGHT ) {
+            if( event.mousebutton == SDL_BUTTON_MIDDLE ) {
                 dragging = false;
                 ctrDrag = false;
                 rightButtonDown = true;
@@ -685,24 +686,24 @@ void GameView::event(const Event& event)
                 leftButtonDown = true;
                 break;
             }
-            if( event.mousebutton == SDL_BUTTON_MIDDLE ) {
+            if( event.mousebutton == SDL_BUTTON_RIGHT ) {
                 if( inCity( getTile( event.mousepos ) ) ) {
-                    getMiniMap()->showMpsEnv( getTile( event.mousepos ) );
+                    // getMiniMap()->showMpsEnv( getTile( event.mousepos ) );
                 }
             }
             break;
         }
         case Event::MOUSEBUTTONUP:
 
-            if(event.mousebutton == SDL_BUTTON_MIDDLE ){
-                getMiniMap()->hideMpsEnv();
+            if(event.mousebutton == SDL_BUTTON_RIGHT ){
+                // getMiniMap()->hideMpsEnv();
             }
 
-            if( event.mousebutton == SDL_BUTTON_RIGHT ){
+            if( event.mousebutton == SDL_BUTTON_MIDDLE ){
                 if ( dragging ) {
                     dragging = false;
                     rightButtonDown = false;
-                    SDL_ShowCursor( SDL_ENABLE );
+                    SDL_SetCursor(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW));
                     getButtonPanel()->selectQueryTool();
                     break;
                 }
@@ -789,10 +790,23 @@ void GameView::event(const Event& event)
                 {   editMap( getTile( event.mousepos ), SDL_BUTTON_LEFT);}
             }
             else if( event.mousebutton == SDL_BUTTON_RIGHT ){           //middle
-              if (getButtonPanel()->selectedQueryTool())
-                recenter(event.mousepos);                               //adjust view
-              else
-                getButtonPanel()->selectQueryTool();
+                // show info on the clicked thing
+                MapPoint point = getTile(event.mousepos);
+                if(!inCity(point)) {
+                    break;
+                }
+                
+                int mod_x, mod_y; // upper left coords of module clicked on
+                if(world(point.x,point.y)->reportingConstruction) {
+                    mod_x = world(point.x,point.y)->reportingConstruction->x;
+                    mod_y = world(point.x,point.y)->reportingConstruction->y;
+                }
+                else {
+                    mod_x = point.x;
+                    mod_y = point.y;
+                }
+                
+                mps_set(mod_x, mod_y, MPS_MAP);
             }
             break;
         case Event::MOUSEWHEEL:
@@ -1729,4 +1743,3 @@ int GameView::buildCost( MapPoint tile )
 IMPLEMENT_COMPONENT_FACTORY(GameView)
 
 /** @file lincity-ng/GameView.cpp */
-

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -678,7 +678,6 @@ void GameView::event(const Event& event)
             if( !dragging && rightButtonDown ) {
                 dragging = true;
                 dragStart = event.mousepos;
-                // This hand has one finger up. I couldn't find the closed hand.
                 setPanningCursor();
                 dragStartTime = SDL_GetTicks(); // Is this unused???
             }

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -85,6 +85,7 @@ GameView::GameView()
     mouseScrollState = 0;
     remaining_images = 0;
     textures_ready = false;
+    panningCursor = NULL;
 }
 
 GameView::~GameView()
@@ -93,6 +94,10 @@ GameView::~GameView()
     SDL_WaitThread( loaderThread, NULL );
     if(gameViewPtr == this)
     {   gameViewPtr = 0;}
+    
+    if(panningCursor) {
+      SDL_FreeCursor(panningCursor);
+    }
 }
 
 //Static function to use with SDL_CreateThread
@@ -674,7 +679,7 @@ void GameView::event(const Event& event)
                 dragging = true;
                 dragStart = event.mousepos;
                 // This hand has one finger up. I couldn't find the closed hand.
-                SDL_SetCursor(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND));
+                setPanningCursor();
                 dragStartTime = SDL_GetTicks(); // Is this unused???
             }
             MapPoint tile = getTile(event.mousepos);
@@ -746,8 +751,8 @@ void GameView::event(const Event& event)
                 if ( dragging ) {
                     dragging = false;
                     rightButtonDown = false;
-                    SDL_SetCursor(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW));
-                    getButtonPanel()->selectQueryTool();
+                    setDefaultCursor();
+                    // getButtonPanel()->selectQueryTool();
                     break;
                 }
                 dragging = false;
@@ -1017,6 +1022,18 @@ void GameView::event(const Event& event)
         default:
             break;
     }
+}
+
+void GameView::setPanningCursor() {
+  if(!panningCursor) {
+    panningCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEALL);
+  }
+  SDL_SetCursor(panningCursor);
+}
+
+void GameView::setDefaultCursor() {
+  // I don't think the default cursor needs to be freed.
+  SDL_SetCursor(SDL_GetDefaultCursor());
 }
 
 /*

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -335,6 +335,31 @@ void GameView::setZoom(float newzoom){
     show( centerTile );
 }
 
+void GameView::zoomMouse(float factor, Vector2 mousepos) {
+  float newzoom = zoom * factor;
+  
+  //if ( newzoom < .0625 ) return;
+  if ( newzoom < .0312 ) newzoom = .0312;
+  if ( newzoom > 4 ) newzoom = 4;
+
+  zoom = newzoom;
+  
+  // fix rounding errors...
+  if(fabs(zoom - 1.0) < .01)
+  {   zoom = 1;}
+
+  tileWidth = defaultTileWidth * zoom;
+  tileHeight = defaultTileHeight * zoom;
+  //a virtual screen containing the whole city
+  virtualScreenWidth = tileWidth * world.len();
+  virtualScreenHeight = tileHeight * world.len();
+  //std::cout << "Zoom " << zoom  << "\n";
+  
+  viewport = (viewport + mousepos) * factor - mousepos;
+  // viewport *= factor;
+  // viewport += mousepos * (factor - 1);
+}
+
 /* set Zoomlevel to 100% */
 void GameView::resetZoom(){
     setZoom( defaultZoom );
@@ -812,10 +837,12 @@ void GameView::event(const Event& event)
         case Event::MOUSEWHEEL:
             if (event.scrolly == 0)
                 break;
+            int x, y;
+            SDL_GetMouseState(&x, &y);
             if (event.scrolly > 0)
-                zoomIn();
+                zoomMouse(sqrt(2.f), Vector2(x, y));
             else
-                zoomOut();
+                zoomMouse(sqrt(0.5), Vector2(x, y));
             break;
 
         case Event::KEYDOWN:

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -96,7 +96,7 @@ GameView::~GameView()
     {   gameViewPtr = 0;}
     
     if(panningCursor) {
-      SDL_FreeCursor(panningCursor);
+        SDL_FreeCursor(panningCursor);
     }
 }
 
@@ -342,34 +342,34 @@ void GameView::setZoom(float newzoom){
 }
 
 void GameView::zoomMouse(float factor, Vector2 mousepos) {
-  float newzoom = zoom * factor;
-  
-  //if ( newzoom < .0625 ) return;
-  if ( newzoom < .0312 ) {
-    newzoom = .0312;
-    factor = newzoom / zoom;
-  }
-  if ( newzoom > 4 ) {
-    newzoom = 4;
-    factor = newzoom / zoom;
-  }
+    float newzoom = zoom * factor;
+    
+    //if ( newzoom < .0625 ) return;
+    if (newzoom < .0312) {
+        newzoom = .0312;
+        factor = newzoom / zoom;
+    }
+    if(newzoom > 4) {
+        newzoom = 4;
+        factor = newzoom / zoom;
+    }
 
-  zoom = newzoom;
-  
-  // fix rounding errors...
-  if(fabs(zoom - 1.0) < .01)
-  {   zoom = 1;}
+    zoom = newzoom;
+    
+    // fix rounding errors...
+    if(fabs(zoom - 1.0) < .01)
+        zoom = 1;
 
-  tileWidth = defaultTileWidth * zoom;
-  tileHeight = defaultTileHeight * zoom;
-  //a virtual screen containing the whole city
-  virtualScreenWidth = tileWidth * world.len();
-  virtualScreenHeight = tileHeight * world.len();
-  //std::cout << "Zoom " << zoom  << "\n";
-  
-  viewport = (viewport + mousepos) * factor - mousepos;
-  
-  requestRedraw();
+    tileWidth = defaultTileWidth * zoom;
+    tileHeight = defaultTileHeight * zoom;
+    //a virtual screen containing the whole city
+    virtualScreenWidth = tileWidth * world.len();
+    virtualScreenHeight = tileHeight * world.len();
+    //std::cout << "Zoom " << zoom  << "\n";
+    
+    viewport = (viewport + mousepos) * factor - mousepos;
+    
+    requestRedraw();
 }
 
 /* set Zoomlevel to 100% */
@@ -630,12 +630,12 @@ void GameView::scroll( void )
 }
 
 void GameView::updateMps(int x, int y) {
-  int mod_x = x, mod_y = y;
-  if(world(x,y)->reportingConstruction && !mpsEnvOnQuery) {
-    mod_x = world(x,y)->reportingConstruction->x;
-    mod_y = world(x,y)->reportingConstruction->y;
-  }
-  mps_set(mod_x, mod_y, mpsEnvOnQuery ? MPS_ENV : MPS_MAP);
+    int mod_x = x, mod_y = y;
+    if(world(x,y)->reportingConstruction && !mpsEnvOnQuery) {
+        mod_x = world(x,y)->reportingConstruction->x;
+        mod_y = world(x,y)->reportingConstruction->y;
+    }
+    mps_set(mod_x, mod_y, mpsEnvOnQuery ? MPS_ENV : MPS_MAP);
 }
 
 /*
@@ -743,7 +743,7 @@ void GameView::event(const Event& event)
         }
         case Event::MOUSEBUTTONUP:
 
-            if(event.mousebutton == SDL_BUTTON_RIGHT ){
+            if( event.mousebutton == SDL_BUTTON_RIGHT ){
                 // getMiniMap()->hideMpsEnv();
             }
 
@@ -938,7 +938,7 @@ void GameView::event(const Event& event)
             }
 */
 
-            if( event.keysym.scancode == SDL_SCANCODE_G){
+            if( event.keysym.scancode == SDL_SCANCODE_G ){
                 mpsEnvOnQuery = !mpsEnvOnQuery;
                 updateMps(mps_x, mps_y);
                 break;
@@ -1031,15 +1031,15 @@ void GameView::event(const Event& event)
 }
 
 void GameView::setPanningCursor() {
-  if(!panningCursor) {
-    panningCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEALL);
-  }
-  SDL_SetCursor(panningCursor);
+    if(!panningCursor) {
+        panningCursor = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEALL);
+    }
+    SDL_SetCursor(panningCursor);
 }
 
 void GameView::setDefaultCursor() {
-  // I don't think the default cursor needs to be freed.
-  SDL_SetCursor(SDL_GetDefaultCursor());
+    // I don't think the default cursor needs to be freed.
+    SDL_SetCursor(SDL_GetDefaultCursor());
 }
 
 /*

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -1037,7 +1037,6 @@ void GameView::setPanningCursor() {
 }
 
 void GameView::setDefaultCursor() {
-    // I don't think the default cursor needs to be freed.
     SDL_SetCursor(SDL_GetDefaultCursor());
 }
 

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -154,6 +154,7 @@ void GameView::parse(XmlReader& reader)
     hideHigh = false;
     showTerrainHeight = false;
     cursorSize = 0;
+    mpsEnvOnQuery = false;
 
     mapOverlay = overlayNone;
     mapMode = MiniMap::NORMAL;
@@ -623,6 +624,15 @@ void GameView::scroll( void )
    requestRedraw();
 }
 
+void GameView::updateMps(int x, int y) {
+  int mod_x = x, mod_y = y;
+  if(world(x,y)->reportingConstruction && !mpsEnvOnQuery) {
+    mod_x = world(x,y)->reportingConstruction->x;
+    mod_y = world(x,y)->reportingConstruction->y;
+  }
+  mps_set(mod_x, mod_y, mpsEnvOnQuery ? MPS_ENV : MPS_MAP);
+}
+
 /*
  * Process event
  */
@@ -825,21 +835,8 @@ void GameView::event(const Event& event)
             else if( event.mousebutton == SDL_BUTTON_RIGHT ){           //middle
                 // show info on the clicked thing
                 MapPoint point = getTile(event.mousepos);
-                if(!inCity(point)) {
-                    break;
-                }
-                
-                int mod_x, mod_y; // upper left coords of module clicked on
-                if(world(point.x,point.y)->reportingConstruction) {
-                    mod_x = world(point.x,point.y)->reportingConstruction->x;
-                    mod_y = world(point.x,point.y)->reportingConstruction->y;
-                }
-                else {
-                    mod_x = point.x;
-                    mod_y = point.y;
-                }
-                
-                mps_set(mod_x, mod_y, MPS_MAP);
+                if(!inCity(point)) break;
+                updateMps(point.x, point.y);
             }
             break;
         case Event::MOUSEWHEEL:
@@ -903,13 +900,13 @@ void GameView::event(const Event& event)
 
             // use G to show ground info aka MpsEnv without middle mouse button
             if( event.keysym.scancode == SDL_SCANCODE_G){
-                if( inCity(tileUnderMouse) ) {
-                    getMiniMap()->showMpsEnv( tileUnderMouse );
-                }
+                // if( inCity(tileUnderMouse) ) {
+                //     getMiniMap()->showMpsEnv( tileUnderMouse );
+                // }
                 break;
             }
             // hotkeys for scrolling pages up and down
-           if(event.keysym.scancode == SDL_SCANCODE_N)
+            if(event.keysym.scancode == SDL_SCANCODE_N)
             {
                 getMiniMap()->scrollPageDown(true);
                 break;
@@ -929,6 +926,12 @@ void GameView::event(const Event& event)
                 break;
             }
 */
+
+            if( event.keysym.scancode == SDL_SCANCODE_G){
+                mpsEnvOnQuery = !mpsEnvOnQuery;
+                updateMps(mps_x, mps_y);
+                break;
+            }
             //Hide High Buildings
             if( event.keysym.scancode == SDL_SCANCODE_H ){
                 if( hideHigh ){

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -645,8 +645,8 @@ void GameView::event(const Event& event)
 {
     switch(event.type) {
         case Event::MOUSEMOTION: {
-            if(getConfig()->useFullScreen) {
-                mouseScrollState = 0;
+            mouseScrollState = 0;
+            if(!dragging) {
                 if( event.mousepos.x < scrollBorder ) {
                     mouseScrollState |= SCROLL_LEFT;
                 } else if( event.mousepos.x > getWidth() - scrollBorder ) {
@@ -854,7 +854,13 @@ void GameView::event(const Event& event)
             else
                 zoomMouse(sqrt(0.5), Vector2(x, y));
             break;
-
+        case Event::WINDOWLEAVE:
+            mouseInGameView = false;
+            mouseScrollState = 0;
+            break;
+        case Event::WINDOWENTER:
+            break;
+        
         case Event::KEYDOWN:
             if( event.keysym.scancode == SDL_SCANCODE_LCTRL || event.keysym.scancode == SDL_SCANCODE_RCTRL ){
                 if (roadDragging)

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -339,8 +339,14 @@ void GameView::zoomMouse(float factor, Vector2 mousepos) {
   float newzoom = zoom * factor;
   
   //if ( newzoom < .0625 ) return;
-  if ( newzoom < .0312 ) newzoom = .0312;
-  if ( newzoom > 4 ) newzoom = 4;
+  if ( newzoom < .0312 ) {
+    newzoom = .0312;
+    factor = newzoom / zoom;
+  }
+  if ( newzoom > 4 ) {
+    newzoom = 4;
+    factor = newzoom / zoom;
+  }
 
   zoom = newzoom;
   

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -356,8 +356,8 @@ void GameView::zoomMouse(float factor, Vector2 mousepos) {
   //std::cout << "Zoom " << zoom  << "\n";
   
   viewport = (viewport + mousepos) * factor - mousepos;
-  // viewport *= factor;
-  // viewport += mousepos * (factor - 1);
+  
+  requestRedraw();
 }
 
 /* set Zoomlevel to 100% */

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -624,16 +624,18 @@ void GameView::event(const Event& event)
 {
     switch(event.type) {
         case Event::MOUSEMOTION: {
-            mouseScrollState = 0;
-            if( event.mousepos.x < scrollBorder ) {
-                mouseScrollState |= SCROLL_LEFT;
-            } else if( event.mousepos.x > getWidth() - scrollBorder ) {
-                mouseScrollState |= SCROLL_RIGHT;
-            }
-            if( event.mousepos.y < scrollBorder ) {
-                mouseScrollState |= SCROLL_UP;
-            } else if( event.mousepos.y > getHeight() - scrollBorder ) {
-                mouseScrollState |= SCROLL_DOWN;
+            if(getConfig()->useFullScreen) {
+                mouseScrollState = 0;
+                if( event.mousepos.x < scrollBorder ) {
+                    mouseScrollState |= SCROLL_LEFT;
+                } else if( event.mousepos.x > getWidth() - scrollBorder ) {
+                    mouseScrollState |= SCROLL_RIGHT;
+                }
+                if( event.mousepos.y < scrollBorder ) {
+                    mouseScrollState |= SCROLL_UP;
+                } else if( event.mousepos.y > getHeight() - scrollBorder ) {
+                    mouseScrollState |= SCROLL_DOWN;
+                }
             }
 
             if( dragging ) {

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -99,6 +99,7 @@ private:
     void drawDiamond( Painter& painter, const Rect2D& rect );
     static int gameViewThread(void* data);
     void setZoom(float newzoom);
+    void zoomMouse(float factor, Vector2 mousepos);
     SDL_Surface* readImage(const std::string& filename);
     void preReadImages(void);
     Texture* readTexture(const std::string& filename);

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -173,6 +173,10 @@ private:
 
     MapPoint realTile( MapPoint tile );
     std::string lastStatusMessage;
+    
+    SDL_Cursor *panningCursor;
+    void setPanningCursor();
+    void setDefaultCursor();
 };
 
 GameView* getGameView();

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -149,6 +149,8 @@ private:
     //       (I didn't bother to refactor the name.)
     MapPoint startRoad;
     bool areaBulldoze;
+    bool mpsEnvOnQuery;
+    void updateMps(int x, int y);
 
     static const float defaultTileWidth;
     static const float defaultTileHeight;

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -144,6 +144,8 @@ private:
     Uint32 dragStartTime;
 
     bool roadDragging, ctrDrag, leftButtonDown;
+    // NOTE: leftButtonDown indicates whether the middle button is down
+    //       (I didn't bother to refactor the name.)
     MapPoint startRoad;
     bool areaBulldoze;
 
@@ -179,4 +181,3 @@ static const int scrollBorder = 5;
 
 
 /** @file lincity-ng/GameView.hpp */
-


### PR DESCRIPTION
A few of the mouse gestures have been really annoying, so this PR changes some of them:

1) Viewport panning is now done by dragging with middle click. Also the direction is changed so it feels more like dragging the map instead of guiding the viewport. I find it way more intuitive to use this way. Also, when dragging, the cursor changes to a hand (previously, the cursor disappeared while dragging the map). Now the mouse wheel can control all map navigation i.e. both panning and zooming.

2) Right click shows information about a building. I find this useful to avoid switching back and forth between the query tool so much. This replaces the previous middle click action which would show information about the tile underneath a building. Viewing info about the tile underneath a building can be toggled with the 'G' key.

3) When zooming with the mouse wheel, the zoom is relative to the pointer. That is, it will now zoom in towards the pointer or out away from the pointer. This is especially useful when zooming in on a specific area. Previously, panning was often required after zooming in.

4) Scrolling by moving the pointer to the screen edge is disabled when the mouse leaves the window. Previously, the map would start scrolling uncontrollably whenever I moved the pointer outside the window.