### PR TITLE
Scrolling improvements

### DIFF
--- a/README
+++ b/README
@@ -114,13 +114,12 @@ any:
  Click on Minimap shows the selected Area on mainscreen.
 
 right:
- Drag mainscreen with right mousebutton.
- right click on mainscreen centers to tile under cursor.
+ right click on mainscreen to show info on building under cursor.
  select tool from menu root
  show help on tool
 
 middle:
- middle click on mainscreen to show information about area under cursor.
+ pan map on mainscreen.
 
 left:
  Perform action depending on selected tool. Bulldoze, show Information,
@@ -158,6 +157,7 @@ use shift + direction to scroll faster
  h  to hide high buildings. Press h again to show them.
  v  to cycle through MiniMap-overlay modes
  b  toggle between current tool and bulldoze mode 
+ g  toggle between right click showing building or tile info
  F1 Help
  
  F12 quick save
@@ -175,4 +175,3 @@ You can contact us at the lincity-ng-devel mailinglist:
 or you might be able to catch us in irc at irc.freenode.net #lincity.
 
 Visit our homepage: https://github.com/lincity-ng/lincity-ng
-

--- a/README
+++ b/README
@@ -131,6 +131,9 @@ wheel:
  up: zoom in
  down: zoom out
 
+motion:
+ move cursor near the screen edge to scroll main screen
+
 Keyboard
 
  ESCAPE switch to query tool
@@ -148,11 +151,12 @@ Keyboard
 
  KP2 scroll main screen se 
  KP4 scroll main screen sw 
- KP6 scroll main screen se 
+ KP6 scroll main screen ne 
  KP8 scroll main screen nw 
- same with cursor
 
-use shift + direction to scroll faster
+ arrow keys or WASD: more ways to scroll
+
+ use shift key to scroll faster
 
  h  to hide high buildings. Press h again to show them.
  v  to cycle through MiniMap-overlay modes

--- a/src/gui/Event.cpp
+++ b/src/gui/Event.cpp
@@ -52,6 +52,18 @@ Event::Event(SDL_Event& event)
             type = MOUSEWHEEL;
             scrolly = event.wheel.y;
             break;
+        case SDL_WINDOWEVENT:
+            switch(event.window.event) {
+            case SDL_WINDOWEVENT_ENTER:
+                type = WINDOWENTER;
+                break;
+            case SDL_WINDOWEVENT_LEAVE:
+                type = WINDOWLEAVE;
+                break;
+            default:
+                type = WINDOWOTHER;
+            }
+            break;
         default:
             assert(false);
     }
@@ -63,4 +75,3 @@ Event::Event(float _elapsedTime)
 }
 
 /** @file gui/Event.cpp */
-

--- a/src/gui/Event.hpp
+++ b/src/gui/Event.hpp
@@ -48,6 +48,12 @@ public:
         MOUSEBUTTONUP,
         /// a mouse wheel has been turned
         MOUSEWHEEL,
+        /// window gained mouse focus
+        WINDOWENTER,
+        /// window lost mouse focus
+        WINDOWLEAVE,
+        /// other window event
+        WINDOWOTHER,
     };
     /// Create an update Event
     Event(float elapsedTime);
@@ -78,4 +84,3 @@ public:
 
 
 /** @file gui/Event.hpp */
-

--- a/src/lincity-ng/Game.cpp
+++ b/src/lincity-ng/Game.cpp
@@ -175,11 +175,18 @@ Game::run()
         while(SDL_PollEvent(&event)) {
             switch(event.type) {
                 case SDL_WINDOWEVENT:
-                    if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED) {
+                    switch(event.window.event) {
+                    case SDL_WINDOWEVENT_SIZE_CHANGED:
                         videoSizeChanged(event.window.data1, event.window.data2);
                         gui->resize(event.window.data1, event.window.data2);
                         getConfig()->videoX = event.window.data1;
                         getConfig()->videoY = event.window.data2;
+                        break;
+                    case SDL_WINDOWEVENT_ENTER:
+                    case SDL_WINDOWEVENT_LEAVE:
+                        Event gui_event(event);
+                        gui->event(gui_event);
+                        break;
                     }
                     break;
                 case SDL_KEYUP: {
@@ -311,4 +318,3 @@ Game::run()
 }
 
 /** @file lincity-ng/Game.cpp */
-

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -808,19 +808,31 @@ void GameView::event(const Event& event)
                 {   ctrDrag = !ctrDrag;}
                 break;
             }
-            if( event.keysym.scancode == SDL_SCANCODE_KP_8 || event.keysym.scancode == SDL_SCANCODE_UP ){
+            if( event.keysym.scancode == SDL_SCANCODE_KP_8 ||
+                event.keysym.scancode == SDL_SCANCODE_UP ||
+                event.keysym.scancode == SDL_SCANCODE_W
+            ){
                 keyScrollState |= SCROLL_UP;
                 break;
             }
-            if( event.keysym.scancode == SDL_SCANCODE_KP_2 || event.keysym.scancode == SDL_SCANCODE_DOWN ){
+            if( event.keysym.scancode == SDL_SCANCODE_KP_2 ||
+                event.keysym.scancode == SDL_SCANCODE_DOWN ||
+                event.keysym.scancode == SDL_SCANCODE_S
+            ){
                 keyScrollState |= SCROLL_DOWN;
                 break;
             }
-            if( event.keysym.scancode == SDL_SCANCODE_KP_4 || event.keysym.scancode == SDL_SCANCODE_LEFT ){
+            if( event.keysym.scancode == SDL_SCANCODE_KP_4 ||
+                event.keysym.scancode == SDL_SCANCODE_LEFT ||
+                event.keysym.scancode == SDL_SCANCODE_A
+            ){
                 keyScrollState |= SCROLL_LEFT;
                 break;
             }
-            if( event.keysym.scancode == SDL_SCANCODE_KP_6 || event.keysym.scancode == SDL_SCANCODE_RIGHT ){
+            if( event.keysym.scancode == SDL_SCANCODE_KP_6 ||
+                event.keysym.scancode == SDL_SCANCODE_RIGHT ||
+                event.keysym.scancode == SDL_SCANCODE_D
+            ){
                 keyScrollState |= SCROLL_RIGHT;
                 break;
             }
@@ -909,19 +921,31 @@ void GameView::event(const Event& event)
                 break;
             }
             //Scroll
-            if( event.keysym.scancode == SDL_SCANCODE_KP_8 || event.keysym.scancode == SDL_SCANCODE_UP ){
+            if( event.keysym.scancode == SDL_SCANCODE_KP_8 ||
+                event.keysym.scancode == SDL_SCANCODE_UP ||
+                event.keysym.scancode == SDL_SCANCODE_W
+            ){
                 keyScrollState &= ~SCROLL_UP;
                 break;
             }
-            if( event.keysym.scancode == SDL_SCANCODE_KP_2 || event.keysym.scancode == SDL_SCANCODE_DOWN ){
+            if( event.keysym.scancode == SDL_SCANCODE_KP_2 ||
+                event.keysym.scancode == SDL_SCANCODE_DOWN ||
+                event.keysym.scancode == SDL_SCANCODE_S
+            ){
                 keyScrollState &= ~SCROLL_DOWN;
                 break;
             }
-            if( event.keysym.scancode == SDL_SCANCODE_KP_4 || event.keysym.scancode == SDL_SCANCODE_LEFT ){
+            if( event.keysym.scancode == SDL_SCANCODE_KP_4 ||
+                event.keysym.scancode == SDL_SCANCODE_LEFT ||
+                event.keysym.scancode == SDL_SCANCODE_A
+            ){
                 keyScrollState &= ~SCROLL_LEFT;
                 break;
             }
-            if( event.keysym.scancode == SDL_SCANCODE_KP_6 || event.keysym.scancode == SDL_SCANCODE_RIGHT ){
+            if( event.keysym.scancode == SDL_SCANCODE_KP_6 ||
+                event.keysym.scancode == SDL_SCANCODE_RIGHT ||
+                event.keysym.scancode == SDL_SCANCODE_D
+            ){
                 keyScrollState &= ~SCROLL_RIGHT;
                 break;
             }

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -560,7 +560,9 @@ void GameView::scroll( void )
     static Uint32 oldTime = SDL_GetTicks();
     Uint32 now = SDL_GetTicks();
     //TODO: scroll speed should be configurable
-    float amt = (now - oldTime) * 0.5;
+    // The sqrt(zoom) makes it feel like the same speed at different zoom
+    // levels.
+    float amt = (now - oldTime) * 0.5 * sqrt(zoom);
     Vector2 dir = Vector2();
     oldTime = now;
     
@@ -575,20 +577,25 @@ void GameView::scroll( void )
     }
 
     if( scrollState & SCROLL_UP_ALL ) {
-        dir.y -= tileHeight;
+        dir.y -= 1;
     }
     if( scrollState & SCROLL_DOWN_ALL ) {
-        dir.y += tileHeight;
+        dir.y += 1;
     }
     if( scrollState & SCROLL_LEFT_ALL ) {
-        dir.x -= tileWidth;
+        dir.x -= 1;
     }
     if( scrollState & SCROLL_RIGHT_ALL ) {
-        dir.x += tileWidth;
+        dir.x += 1;
     }
     
-    float norm = hypot(dir.x, dir.y);
+    // The sqrt((float)tileWidth / tileHeight) makes vertical/horizonal
+    // scrolling feel like the same speed. Surprisingly, without the square
+    // root, it doesn't feel right.
+    float norm = hypot(dir.x * sqrt((float)tileWidth / tileHeight), dir.y);
     if(norm == 0) return;
+    // This makes diagonal scrolling parallel to map components.
+    dir.x *= (float)tileWidth / tileHeight;
     viewport += dir * amt / norm;
     
     constrainViewportPosition();

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -719,10 +719,20 @@ void GameView::event(const Event& event)
                 if(event.mousepos == dragStart)
                     break;
                 viewport -= event.mousemove;
+                viewport += panAnchorCorrection;
+                panAnchorCorrection = viewport;
                 constrainViewportPosition();
+                panAnchorCorrection -= viewport;
                 setDirty();
                 break;
             }
+            if(!rightButtonDown) {
+              // Use `rightButtonDown` instead of `dragging` so releasing and
+              // re-pressing the button does not lose the drag correction. Such
+              // a release and re-press was probably a mistake.
+              panAnchorCorrection = Vector2(0,0);
+            }
+            
             if(!event.inside) {
                 mouseInGameView = false;
                 break;

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -560,8 +560,8 @@ void GameView::scroll( void )
     static Uint32 oldTime = SDL_GetTicks();
     Uint32 now = SDL_GetTicks();
     //TODO: scroll speed should be configurable
-    float stepx = (now - oldTime) * tileWidth / 100;
-    float stepy = (now - oldTime) * tileHeight / 100;
+    float amt = (now - oldTime) * 0.5;
+    Vector2 dir = Vector2();
     oldTime = now;
     
     int scrollState = keyScrollState | mouseScrollState;
@@ -571,22 +571,26 @@ void GameView::scroll( void )
     }
 
     if( keyScrollState & SCROLL_SHIFT_ALL ) {
-        stepx *= 4;
-        stepy *= 4;
+        amt *= 4;
     }
 
     if( scrollState & SCROLL_UP_ALL ) {
-        viewport.y -= stepy;
+        dir.y -= tileHeight;
     }
     if( scrollState & SCROLL_DOWN_ALL ) {
-        viewport.y += stepy;
+        dir.y += tileHeight;
     }
     if( scrollState & SCROLL_LEFT_ALL ) {
-        viewport.x -= stepx;
+        dir.x -= tileWidth;
     }
     if( scrollState & SCROLL_RIGHT_ALL ) {
-        viewport.x += stepx;
+        dir.x += tileWidth;
     }
+    
+    float norm = hypot(dir.x, dir.y);
+    if(norm == 0) return;
+    viewport += dir * amt / norm;
+    
     requestRedraw();
 }
 

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -81,8 +81,8 @@ GameView::GameView()
     assert(gameViewPtr == 0);
     gameViewPtr = this;
     loaderThread = 0;
-    keyScrollState = 0;
-    mouseScrollState = 0;
+    keyScrollState = SCROLL_NONE;
+    mouseScrollState = SCROLL_NONE;
     remaining_images = 0;
     textures_ready = false;
 }
@@ -563,33 +563,31 @@ void GameView::scroll( void )
     float stepx = (now - oldTime) * tileWidth / 100;
     float stepy = (now - oldTime) * tileHeight / 100;
     oldTime = now;
+    
+    int scrollState = keyScrollState | mouseScrollState;
 
-    if( keyScrollState == 0 && mouseScrollState == 0 ) {
+    if( scrollState == SCROLL_NONE ) {
         return;
     }
 
-    if( keyScrollState & (SCROLL_LSHIFT | SCROLL_RSHIFT) ) {
+    if( keyScrollState & SCROLL_SHIFT_ALL ) {
         stepx *= 4;
         stepy *= 4;
     }
 
-    if( (keyScrollState | mouseScrollState) &
-            (SCROLL_UP | SCROLL_UP_LEFT | SCROLL_UP_RIGHT) ) {
+    if( scrollState & SCROLL_UP_ALL ) {
         viewport.y -= stepy;
     }
-    if( (keyScrollState | mouseScrollState) &
-            (SCROLL_DOWN | SCROLL_DOWN_LEFT | SCROLL_DOWN_RIGHT) ) {
+    if( scrollState & SCROLL_DOWN_ALL ) {
         viewport.y += stepy;
     }
-    if( (keyScrollState | mouseScrollState) &
-            (SCROLL_LEFT | SCROLL_UP_LEFT | SCROLL_DOWN_LEFT) ) {
+    if( scrollState & SCROLL_LEFT_ALL ) {
         viewport.x -= stepx;
     }
-    if( (keyScrollState | mouseScrollState) &
-            (SCROLL_RIGHT | SCROLL_UP_RIGHT | SCROLL_DOWN_RIGHT) ) {
+    if( scrollState & SCROLL_RIGHT_ALL ) {
         viewport.x += stepx;
     }
-   requestRedraw();
+    requestRedraw();
 }
 
 /*
@@ -599,7 +597,7 @@ void GameView::event(const Event& event)
 {
     switch(event.type) {
         case Event::MOUSEMOTION: {
-            mouseScrollState = 0;
+            mouseScrollState = SCROLL_NONE;
             if( event.mousepos.x < scrollBorder ) {
                 mouseScrollState |= SCROLL_LEFT;
             } else if( event.mousepos.x > getWidth() - scrollBorder ) {
@@ -1457,8 +1455,8 @@ void GameView::draw(Painter& painter)
     }
     if( outside )
     {
-        mouseScrollState = 0;   //Avoid clipping in pause mode
-        keyScrollState = 0;
+        mouseScrollState = SCROLL_NONE;   //Avoid clipping in pause mode
+        keyScrollState = SCROLL_NONE;
         show( centerTile );
         return;
     }
@@ -1729,4 +1727,3 @@ int GameView::buildCost( MapPoint tile )
 IMPLEMENT_COMPONENT_FACTORY(GameView)
 
 /** @file lincity-ng/GameView.cpp */
-

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -1456,7 +1456,7 @@ void GameView::draw(Painter& painter)
     if( outside )
     {
         mouseScrollState = SCROLL_NONE;   //Avoid clipping in pause mode
-        keyScrollState = SCROLL_NONE;
+        keyScrollState &= SCROLL_SHIFT_ALL;
         show( centerTile );
         return;
     }

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -719,10 +719,11 @@ void GameView::event(const Event& event)
                 if(event.mousepos == dragStart)
                     break;
                 viewport -= event.mousemove;
-                viewport += panAnchorCorrection;
+                viewport += panAnchorCorrection * zoom;
                 panAnchorCorrection = viewport;
                 constrainViewportPosition();
                 panAnchorCorrection -= viewport;
+                panAnchorCorrection /= zoom;
                 setDirty();
                 break;
             }

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -1508,12 +1508,10 @@ void GameView::markTile( Painter& painter, const MapPoint &tile )
  */
 void GameView::draw(Painter& painter)
 {
-    // I'm not sure why we need to return here. If it does return, then it will
-    // cause an aparant lag. Good news is this should never happen if zooming
-    // and scrolling do their job right. But it could still happen occasionally
-    // due to roundoff error. If there is round-off error and this does not
-    // correct it, then the next draw iteration may also lag.
-    if( constrainViewportPosition() ) return; // not sure why we need to return
+    if( constrainViewportPosition() ) {
+      // Returning causes the display to lag. I'm not sure why it's needed anyway.
+      // return;
+    }
 
     //The Corners of The Screen
     Vector2 upperLeft( 0, 0);

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -670,6 +670,7 @@ void GameView::event(const Event& event)
                 if(event.mousepos == dragStart)
                     break;
                 viewport += event.mousemove;
+                constrainViewportPosition();
                 setDirty();
                 break;
             }

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -99,6 +99,7 @@ private:
     void drawDiamond( Painter& painter, const Rect2D& rect );
     static int gameViewThread(void* data);
     void setZoom(float newzoom);
+    bool constrainViewportPosition();
     SDL_Surface* readImage(const std::string& filename);
     void preReadImages(void);
     Texture* readTexture(const std::string& filename);

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -110,6 +110,7 @@ private:
     float virtualScreenWidth, virtualScreenHeight;
 
     enum {
+        SCROLL_NONE = 0x0,
         SCROLL_UP = 1,
         SCROLL_DOWN = (1 << 1),
         SCROLL_LEFT = (1 << 2),
@@ -119,7 +120,12 @@ private:
         SCROLL_DOWN_LEFT = (1 << 6),
         SCROLL_DOWN_RIGHT = (1 << 7),
         SCROLL_LSHIFT = (1 << 8),
-        SCROLL_RSHIFT = (1 << 9)
+        SCROLL_RSHIFT = (1 << 9),
+        SCROLL_UP_ALL = SCROLL_UP | SCROLL_UP_LEFT | SCROLL_UP_RIGHT,
+        SCROLL_DOWN_ALL = SCROLL_DOWN | SCROLL_DOWN_LEFT | SCROLL_DOWN_RIGHT,
+        SCROLL_LEFT_ALL = SCROLL_LEFT | SCROLL_UP_LEFT | SCROLL_DOWN_LEFT,
+        SCROLL_RIGHT_ALL = SCROLL_RIGHT | SCROLL_UP_RIGHT | SCROLL_DOWN_RIGHT,
+        SCROLL_SHIFT_ALL = SCROLL_LSHIFT | SCROLL_RSHIFT,
     };
     int keyScrollState;
     int mouseScrollState;
@@ -179,4 +185,3 @@ static const int scrollBorder = 5;
 
 
 /** @file lincity-ng/GameView.hpp */
-

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -150,6 +150,7 @@ private:
     bool mouseInGameView;
     bool dragging, rightButtonDown;
     Uint32 dragStartTime;
+    Vector2 panAnchorCorrection;
 
     bool roadDragging, ctrDrag, leftButtonDown;
     // NOTE: leftButtonDown indicates whether the middle button is down

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -99,6 +99,7 @@ private:
     void drawDiamond( Painter& painter, const Rect2D& rect );
     static int gameViewThread(void* data);
     void setZoom(float newzoom);
+    void zoomMouse(float factor, Vector2 mousepos);
     bool constrainViewportPosition();
     SDL_Surface* readImage(const std::string& filename);
     void preReadImages(void);
@@ -151,8 +152,12 @@ private:
     Uint32 dragStartTime;
 
     bool roadDragging, ctrDrag, leftButtonDown;
+    // NOTE: leftButtonDown indicates whether the middle button is down
+    //       (I didn't bother to refactor the name.)
     MapPoint startRoad;
     bool areaBulldoze;
+    bool mpsEnvOnQuery;
+    void updateMps(int x, int y);
 
     static const float defaultTileWidth;
     static const float defaultTileHeight;
@@ -175,6 +180,10 @@ private:
 
     MapPoint realTile( MapPoint tile );
     std::string lastStatusMessage;
+    
+    SDL_Cursor *panningCursor;
+    void setPanningCursor();
+    void setDefaultCursor();
 };
 
 GameView* getGameView();

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -100,7 +100,7 @@ private:
     static int gameViewThread(void* data);
     void setZoom(float newzoom);
     void zoomMouse(float factor, Vector2 mousepos);
-    bool constrainViewportPosition();
+    bool constrainViewportPosition(bool useScrollCorrection);
     SDL_Surface* readImage(const std::string& filename);
     void preReadImages(void);
     Texture* readTexture(const std::string& filename);
@@ -150,7 +150,7 @@ private:
     bool mouseInGameView;
     bool dragging, rightButtonDown;
     Uint32 dragStartTime;
-    Vector2 panAnchorCorrection;
+    Vector2 scrollCorrection;
 
     bool roadDragging, ctrDrag, leftButtonDown;
     // NOTE: leftButtonDown indicates whether the middle button is down


### PR DESCRIPTION
This implements various improvements to the scrolling behavior and hitting the map edge.

- **Adds scrolling with WASD.**
- **Tweaks the scrolling speed in different directions when using the keyboard.** Now, scrolling vertically, horizontally, and diagonally feels more like the same speed. Previously, horizontal scrolling felt faster than vertical scrolling due to the distortion of the tiles, and diagonal scrolling was substantially faster because it added horizontal and vertical scrolling with no normalization.
- **Tweaks the scrolling speed with the keyboard at different zoom levels.** Now, scrolling feels appropriately faster when zoomed out.
- **Anchors the cursor when panning, and keeps the anchor position when hitting the map edge.** Previously, the anchor position would change when pushing against the map edge.
- **Removes lag when scrolling against the map edge.** Previously, hitting the edge would cause the draw function to skip a beat (or a lot more beats).
- **Makes scrolling against the map edge smoother.** Previously, the logic which reset the viewport position would move the viewport to the center of an edge tile, and this made the viewport jump a half tile. Now, the viewport center is constrained to and reset to the edge of the outside tile to avoid the jump.
- **Removes the teleport effect of zooming in and out.** Previously, when the map edge was hit while zooming out, it would shift the viewport and consequently the cursor so that zooming back in would not go to the same place. A similar effect could happen when zooming in and then out. This was particularly annoying when the zoom was accidental because zooming the opposite direction would not get back to the same position. Now, if the viewport is shifted from hitting the map edge, then zooming in the opposite direction will un-shift it. Moving the mouse will cancel the saved shift.
- **Persists the shift key when hitting the map edge.** Previously, when the map edge was hit with the shift key pressed, the game would forget that the shift key was pressed -- shift would have to be released and pressed again to re-enable fast scrolling. Now, this is fixed.

**Note: This PR is based on commits from PR #66, so this should not be merged until after PR #66 is merged.** Otherwise, this is ready for review even though it is marked as a draft.