### PR TITLE
configure.ac: Fix incompatible pointer type in zlib probe

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -86,7 +86,7 @@ AM_BINRELOC
 
 NP_FINDLIB([ZLIB], [zlib], [zlib],
 	NP_LANG_PROGRAM([[#include <zlib.h>]],
-            [[gzFile* file = gzopen("", "");]]),
+            [[gzFile file = gzopen("", "");]]),
 	[], [-lz],
 	[],
 	[AC_MSG_ERROR([Please install zlib])])


### PR DESCRIPTION
The gzopen function returns type `gzFile`, and not `gzFile *` as previously assumed.  This error causes the probe to fail unconditionally even if zlib is available if the compiler treats such incompatible types as errors (because they are not valid C).

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
