### PR TITLE
fix compiler warnings with -Wall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ project(lincity-ng
 include(CheckIncludeFiles)
 include(GNUInstallDirs)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/src/gui/Gradient.cpp
+++ b/src/gui/Gradient.cpp
@@ -66,7 +66,7 @@ Gradient::parse(XmlReader& reader)
                 std::stringstream msg;
                 msg << "Invalid gradient direction '" << value << "'.";
                 throw std::runtime_error(msg.str());
-            }   
+            }
         } else {
             std::cerr << "Skipping unknown attribute '"
                       << attribute << "'.\n";
@@ -79,14 +79,8 @@ Gradient::parse(XmlReader& reader)
 void
 Gradient::resize(float width, float height)
 {
-    float w;
-    if(direction == LEFT_RIGHT)
-        w = width;
-    else if(direction == TOP_BOTTOM)
-        w = height;
-    else
-        assert(false);
-    
+    assert(direction == LEFT_RIGHT || direction == TOP_BOTTOM);
+    float w = direction == LEFT_RIGHT ? width : height;
     float dr = ((float) to.r - (float) from.r) / w;
     float dg = ((float) to.g - (float) from.g) / w;
     float db = ((float) to.b - (float) from.b) / w;
@@ -156,7 +150,7 @@ Gradient::draw_horizontal_line(SDL_Surface* surface, int x1, int y1, int x2,
         | (uint32_t) g << surface->format->Gshift
         | (uint32_t) b << surface->format->Bshift
         | (uint32_t) a << surface->format->Ashift;
-    
+
     uint8_t* pix = (uint8_t*) surface->pixels + (y1*surface->pitch) + x1*4;
     for(int x = x1; x < x2; ++x) {
         uint32_t* p = (uint32_t*) pix;
@@ -174,7 +168,7 @@ Gradient::draw_vertical_line(SDL_Surface* surface, int x1, int y1, int y2,
         | (uint32_t) b << surface->format->Bshift
         | (uint32_t) a << surface->format->Ashift;
     int pitch = surface->pitch;
-    
+
     uint8_t* pix = (uint8_t*) surface->pixels + (y1*pitch) + x1*4;
     for(int y = y1; y < y2; ++y) {
         uint32_t* p = (uint32_t*) pix;
@@ -186,4 +180,3 @@ Gradient::draw_vertical_line(SDL_Surface* surface, int x1, int y1, int y2,
 IMPLEMENT_COMPONENT_FACTORY(Gradient)
 
 /** @file gui/Gradient.cpp */
-

--- a/src/lincity-ng/Dialog.cpp
+++ b/src/lincity-ng/Dialog.cpp
@@ -492,7 +492,7 @@ void Dialog::saveGameStats(){
         strlen(lc_save_dir) + strlen(RESULTS_FILENAME) + 2);
     if(!s)
         error(-1, errno, "malloc");
-    sprintf(s, "%s%c%s",
+    sprintf(s, "%s%s%s",
         lc_save_dir, PHYSFS_getDirSeparator(), RESULTS_FILENAME);
 
     std::ofstream results( s );
@@ -509,7 +509,10 @@ void Dialog::saveGameStats(){
     snprintf (outf, maxlength, "Game statistics from LinCity-NG Version %s", PACKAGE_VERSION);
     results << outf << std::endl;
     if (strlen (given_scene) > 3){
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wformat-truncation"
         snprintf (outf, maxlength, "Initial loaded scene - %s", given_scene);
+        #pragma GCC diagnostic pop
         results << outf << std::endl;
     }
     if (sustain_flag){

--- a/src/lincity-ng/Game.cpp
+++ b/src/lincity-ng/Game.cpp
@@ -182,6 +182,7 @@ Game::run()
     int frame = 0;
 
     Uint32 next_execute = 0, next_animate = 0, next_gui = 0, next_fps = 0;
+    __attribute__((unused))
     Uint32 prev_execute = 0, prev_animate = 0, prev_gui = 0, prev_fps = 0;
     Uint32 next_task;
     Uint32 tick;
@@ -364,11 +365,11 @@ Game::run()
 
         // this is kind of janky, but it works for now
         if( lincitySpeed == 0 || blockingDialogIsOpen ) {
-             // deschedule execute and animate
+            // deschedule execute and animate
             next_execute = ~0;
             next_animate = ~0;
         }
-        else if(next_execute == -1 || next_animate == -1) {
+        else if(next_execute == (Uint32)~0 || next_animate == (Uint32)~0) {
             // reschedule execute and animate
             next_execute = tick;
             next_animate = tick;

--- a/src/lincity/lin-city.h
+++ b/src/lincity/lin-city.h
@@ -113,8 +113,8 @@
 // This helps animation keep a consistent speed with varying fps.
 #define ANIM_THRESHOLD(millis) (((millis) + ANIMATE_DELAY / 2) \
   / ANIMATE_DELAY * ANIMATE_DELAY - ANIMATE_DELAY / 2)
-// #define ANIM_THRESHOLD(millis) \
-  (millis - (millis + ANIMATE_DELAY / 2) % ANIMATE_DELAY)
+/* #define ANIM_THRESHOLD(millis) \
+  (millis - (millis + ANIMATE_DELAY / 2) % ANIMATE_DELAY) */
 
 #define MIN_RES_POPULATION 10
 

--- a/src/lincity/modules/commune.cpp
+++ b/src/lincity/modules/commune.cpp
@@ -113,7 +113,7 @@ void Commune::animate() {
     frame += (frame >= 6 ? -5 : 0) + (steel_made ? 5 : 0);
     steel_made = false;
 
-    if(frame >= frameIt->resourceGroup->graphicsInfoVector.size())
+    if(frame >= (int)frameIt->resourceGroup->graphicsInfoVector.size())
       // this should never happen
       frame = 1;
   }

--- a/src/lincity/modules/oremine.cpp
+++ b/src/lincity/modules/oremine.cpp
@@ -111,11 +111,11 @@ void Oremine::animate() {
     //faster animation for more active mines
     anim = real_time + ANIM_THRESHOLD((14 - busy/11) * OREMINE_ANIMATION_SPEED);
     if(anim_count < 8)
-      frameIt->frame = anim_count;
+      frame = anim_count;
     else if (anim_count < 12)
-      frameIt->frame = 14 - anim_count;
+      frame = 14 - anim_count;
     else
-      frameIt->frame = 16 - anim_count;
+      frame = 16 - anim_count;
     if(++anim_count == 16)
       anim_count = 0;
   }

--- a/src/lincity/modules/port.cpp
+++ b/src/lincity/modules/port.cpp
@@ -55,9 +55,7 @@ int Port::sell_stuff(Commodity stuff)
 void Port::trade_connection()
 {
     //Checks all flags and issues buy_stuff sell_stuff accordingly
-    std::array<CommodityRule, STUFF_COUNT>::iterator stuff_it;
-    for(Commodity stuff = STUFF_INIT ; stuff < STUFF_COUNT ; stuff++ )
-    {
+    for(Commodity stuff = STUFF_INIT; stuff < STUFF_COUNT; stuff++ ) {
         CommodityRule& rule = commodityRuleCount[stuff];
         if(!rule.maxload) continue;
         if (rule.take == rule.give)


### PR DESCRIPTION
Fixes some compiler warnings when compiling with -Wall. Also allows setting the C++ standard from the command line.