### PR TITLE
Production report

### DIFF
--- a/src/gui_interface/mps.h
+++ b/src/gui_interface/mps.h
@@ -32,6 +32,7 @@ static const int MPS_PARAGRAPH_COUNT = 13;
 int mps_set(int x, int y, int style); /* Attaches an area or global display */
 void mps_refresh(void); /* refresh the information display's contents */
 void mps_update(void);  /* Update text contents for later display (refresh) */
+void mps_scroll_page(bool forward); /* rotate through mps pages */
 
 
 /* mps_info storage functions; place values of corresponding type into
@@ -79,4 +80,3 @@ void mps_right (int x, int y);
 
 
 /** @file gui_interface/mps.h */
-

--- a/src/gui_interface/pbar_interface.h
+++ b/src/gui_interface/pbar_interface.h
@@ -40,15 +40,15 @@ void update_pbars_monthly(void);
 #define PHOUSE 14
 
 /* Number of elements per pbar */
-#define PBAR_DATA_SIZE 12
+#define PBAR_DATA_SIZE 1
 
 struct pbar_st
 {
-    int oldtot;
-    int tot;
+    int oldtot; // unused
+    int tot; // unused
     int diff;
 
-    int data_size;
+    int data_size; // unused
     int data[PBAR_DATA_SIZE];
 };
 
@@ -61,4 +61,3 @@ extern struct pbar_st pbars[NUM_PBARS];
 
 
 /** @file gui_interface/pbar_interface.h */
-

--- a/src/lincity-ng/MpsInterface.cpp
+++ b/src/lincity-ng/MpsInterface.cpp
@@ -79,8 +79,9 @@ int mps_set( int x, int y, int style ) /* Attaches an area or global display */
     if(! getGame()) //there may be no longer a game when shuting down lincity
     {   return -1;}
     int same_square = mps_set_silent(x, y, style);
-    if(same_square)
-    {   mps_map_page = (mps_map_page + 1)%MPS_MAP_PAGES;}
+    if(same_square) {
+        mps_scroll_page(true);
+    }
 
     switch(style) {
         case MPS_MAP:
@@ -178,6 +179,22 @@ void mps_refresh() /* refresh the information display's contents */
         default:
             break;
     }
+}
+
+void mps_scroll_page(bool forward) {
+  if(mps_style == MPS_MAP && world.is_visible(mps_x, mps_y)) {
+    int num_pages = world(mps_x, mps_y)->getConstructionGroup()->mps_pages;
+    if(num_pages >= 2) {
+      if(forward) {
+        if(++mps_map_page >= num_pages)
+          mps_map_page = 0;
+      }
+      else {
+        if(mps_map_page-- <= 0)
+          mps_map_page = num_pages - 1;
+      }
+    }
+  }
 }
 
 /** Update text contents for later display (refresh) */
@@ -549,4 +566,3 @@ void mps_global_housing()
 
 
 /** @file lincity-ng/MpsInterface.cpp */
-

--- a/src/lincity-ng/PbarInterface.cpp
+++ b/src/lincity-ng/PbarInterface.cpp
@@ -29,32 +29,16 @@ void update_pbar (int pbar_num, int value, int month_flag)
 {
     // copy of update_pbar from src/oldgui/pbar.cpp
     // store values for savegame
-    int i;
     struct pbar_st * pbar = &pbars[pbar_num];
+    int old = pbar->data[0];
 
-    if (month_flag) {
-         pbar->oldtot = pbar->tot;
-
-        /* If the dataset isn't full, just add it and forget month_flag */
-        if (pbar->data_size < PBAR_DATA_SIZE)
-        {
-            pbar->oldtot += pbar->data[0];// new total has one additional value
-            pbar->data_size++;
-            month_flag = 0;
+    if(month_flag) {
+        for(int i = 0; i < PBAR_DATA_SIZE - 1; i++) {
+            pbar->data[i] = pbar->data[i+1];
         }
+        pbar->data[PBAR_DATA_SIZE - 1] = value;
     }
-
-    pbar->tot = 0;
-
-    for (i = 0; i < (pbar->data_size - 1); i++)
-    {
-        if (month_flag)
-        {   pbar->tot += (pbar->data[i] = pbar->data[i+1]);}
-        else
-        {   pbar->tot += pbar->data[i];}
-    }
-    pbar->tot += pbar->data[i] = value;
-    pbar->diff = pbar->tot - pbar->oldtot;
+    pbar->diff = value - old;
 
     // new: update bars
     if(LCPBarPage1 && LCPBarPage2)
@@ -71,9 +55,9 @@ void refresh_pbars (void)
         {
             struct pbar_st * pbar = &pbars[p];
             if (pbarGlobalStyle == 0)
-            {   LCPBarPage1->setValue(p,pbar->data[pbar->data_size - 1],pbar->diff);}
+            {   LCPBarPage1->setValue(p,pbar->data[PBAR_DATA_SIZE - 1],pbar->diff);}
             else if (pbarGlobalStyle == 1)
-            {   LCPBarPage2->setValue(p,pbar->data[pbar->data_size - 1],pbar->diff);}
+            {   LCPBarPage2->setValue(p,pbar->data[PBAR_DATA_SIZE - 1],pbar->diff);}
         }
 }
 
@@ -85,7 +69,7 @@ void init_pbars (void)
         pbars[p].data_size = 0;
         pbars[p].oldtot = 0;
         pbars[p].tot = 0;
-        pbars[p].diff = 1;
+        pbars[p].diff = 0;
         for (i = 0; i < PBAR_DATA_SIZE; i++)
         {   pbars[p].data[i] = 0;}
     }
@@ -97,38 +81,18 @@ void update_pbars_monthly()
     update_pbar (PPOP, housed_population + people_pool, 1);
     update_pbar (PTECH, tech_level, 1);
     update_pbar (PMONEY, total_money, 1);
-    if (tstat_capacities[STUFF_FOOD] > 999)
-    {    update_pbar (PFOOD, tstat_census[STUFF_FOOD] / (tstat_capacities[STUFF_FOOD]/1000), 1);}
-    else update_pbar (PFOOD,0,1);
-    if (tstat_capacities[STUFF_JOBS] > 999)
-    {    update_pbar (PJOBS, tstat_census[STUFF_JOBS] / ( tstat_capacities[STUFF_JOBS]/1000), 1);}
-    else update_pbar (PJOBS,0,1);
-    if (tstat_capacities[STUFF_GOODS] > 999)
-    {    update_pbar (PGOODS, tstat_census[STUFF_GOODS] / ( tstat_capacities[STUFF_GOODS]/1000), 1);}
-    else update_pbar (PGOODS,0,1);
-    if (tstat_capacities[STUFF_COAL] > 999)
-    {    update_pbar (PCOAL, tstat_census[STUFF_COAL] / ( tstat_capacities[STUFF_COAL]/1000), 1);}
-    else update_pbar (PCOAL,0,1);
-    if (tstat_capacities[STUFF_ORE] > 999)
-    {    update_pbar (PORE, tstat_census[STUFF_ORE] / ( tstat_capacities[STUFF_ORE]/1000), 1);}
-    else update_pbar (PORE,0,1);
-    if (tstat_capacities[STUFF_STEEL] > 999)
-    {    update_pbar (PSTEEL, tstat_census[STUFF_STEEL] / ( tstat_capacities[STUFF_STEEL]/1000), 1);}
-    else update_pbar (PSTEEL,0,1);
+    update_pbar (PFOOD, tstat_census[STUFF_FOOD] * 1000L / tstat_capacities[STUFF_FOOD], 1);
+    update_pbar (PJOBS, tstat_census[STUFF_JOBS] * 1000L / tstat_capacities[STUFF_JOBS], 1);
+    update_pbar (PGOODS, tstat_census[STUFF_GOODS] * 1000L / tstat_capacities[STUFF_GOODS], 1);
+    update_pbar (PCOAL, tstat_census[STUFF_COAL] * 1000L / tstat_capacities[STUFF_COAL], 1);
+    update_pbar (PORE, tstat_census[STUFF_ORE] * 1000L / tstat_capacities[STUFF_ORE], 1);
+    update_pbar (PSTEEL, tstat_census[STUFF_STEEL] * 1000L / tstat_capacities[STUFF_STEEL], 1);
 
     update_pbar (PPOL, total_pollution, 1);
-    if (tstat_capacities[STUFF_KWH] > 999)
-    {    update_pbar (PKWH, tstat_census[STUFF_KWH] / ( tstat_capacities[STUFF_KWH]/1000), 1);}
-    else update_pbar (PKWH,0,1);
-    if (tstat_capacities[STUFF_MWH] > 999)
-    {    update_pbar (PMWH, tstat_census[STUFF_MWH] / ( tstat_capacities[STUFF_MWH]/1000), 1);}
-    else update_pbar (PMWH,0,1);
-    if (tstat_capacities[STUFF_WATER] > 999)
-    {    update_pbar (PWATER, tstat_census[STUFF_WATER] / ( tstat_capacities[STUFF_WATER]/1000), 1);}
-    else update_pbar (PWATER,0,1);
-    if (tstat_capacities[STUFF_WASTE] > 999)
-    {    update_pbar (PWASTE, tstat_census[STUFF_WASTE] / (tstat_capacities[STUFF_WASTE]/1000), 1);}
-    else update_pbar (PWASTE,0,1);
+    update_pbar (PKWH, tstat_census[STUFF_KWH] * 1000L / tstat_capacities[STUFF_KWH], 1);
+    update_pbar (PMWH, tstat_census[STUFF_MWH] * 1000L / tstat_capacities[STUFF_MWH], 1);
+    update_pbar (PWATER, tstat_census[STUFF_WATER] * 1000L / tstat_capacities[STUFF_WATER], 1);
+    update_pbar (PWASTE, tstat_census[STUFF_WASTE] * 1000L / tstat_capacities[STUFF_WASTE], 1);
     if (total_housing)
     {    update_pbar (PHOUSE, (1000 * housed_population)/total_housing , 1);}
     else update_pbar (PHOUSE,0,1);
@@ -136,4 +100,3 @@ void update_pbars_monthly()
 }
 
 /** @file lincity-ng/PbarInterface.cpp */
-

--- a/src/lincity-ng/ScreenInterface.cpp
+++ b/src/lincity-ng/ScreenInterface.cpp
@@ -328,7 +328,6 @@ void print_stats ()
     // this show update the financy window or mps
     if (total_time % NUMOF_DAYS_IN_MONTH == (NUMOF_DAYS_IN_MONTH - 1))
     {
-        update_pbars_monthly();
         mps_refresh();
         getEconomyGraph()->updateData();
     }

--- a/src/lincity/all_buildings.h
+++ b/src/lincity/all_buildings.h
@@ -132,7 +132,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 1/*mps_pages*/
     ) {
 
     };
@@ -152,4 +153,3 @@ extern TileConstructionGroup tree3ConstructionGroup;
 #endif // __all_buildings_h__
 
 /** @file lincity/all_buildings.h */
-

--- a/src/lincity/lintypes.cpp
+++ b/src/lincity/lintypes.cpp
@@ -453,10 +453,10 @@ void Construction::list_commodities(int *i) {
     switch(mps_map_page) {
     default:
     case 0:
-        list_commodities(&i);
+        list_inventory(i);
         break;
     case 1:
-        list_production(&i);
+        list_production(i);
         break;
     }
 }

--- a/src/lincity/lintypes.cpp
+++ b/src/lincity/lintypes.cpp
@@ -583,22 +583,24 @@ void Construction::reset_prod_counters(void) {
         commodityProd[stuff] = 0;
 #if DEBUG
     if(commodityProdPrev[stuff] > commodityMaxProd[stuff]) {
-        commodityMaxProd[stuff] = commodityProdPrev[stuff];
-        std::cerr << "error (non-fatal):"
+        // commodityMaxProd[stuff] = commodityProdPrev[stuff];
+        std::cerr << "warning:"
           << " construction "
           << constructionGroup->name
           << " exceeded maximum production of commodity "
-          << commodityNames[stuff]
-          << ". Updating maximum production." << '\n';
+          << commodityNames[stuff] << "."
+          // << " Updating maximum production."
+          << '\n';
     }
     if(-commodityProdPrev[stuff] > commodityMaxCons[stuff]) {
-        commodityMaxCons[stuff] = -commodityProdPrev[stuff];
-        std::cerr << "error (non-fatal):"
+        // commodityMaxCons[stuff] = -commodityProdPrev[stuff];
+        std::cerr << "warning:"
           << " construction "
           << constructionGroup->name
           << " exceeded maximum consumption of commodity "
-          << commodityNames[stuff]
-          << ". Updating maximum consumption." << '\n';
+          << commodityNames[stuff] << "."
+          // << " Updating maximum production."
+          << '\n';
     }
 #endif
     } //endfor
@@ -926,6 +928,45 @@ void Construction::saveMembers(std::ostream *os)
             assert(checksum == xml_tmp->len());
         }
     }
+}
+
+void Construction::place() {
+  initialize();
+
+#ifdef DEBUG
+   //default resources if no manual settings for construction
+  if (!soundGroup) {
+    std::cout << "Warning no explicit sound, graphics resources specified for "
+      << constructionGroup->name << " at " << "(" << x << ", " << y << ")"
+      << std::endl;
+    init_resources();
+  }
+#endif
+
+  unsigned short size = constructionGroup->size;
+  for (unsigned short i = 0; i < size; i++) {
+    for (unsigned short j = 0; j < size; j++) {
+      //never change water upon building something
+      if(!world(x + j, y + i)->is_water()) {
+        if(!(flags & FLAG_TRANSPARENT)) {
+          world(x + j, y + i)->setTerrain(GROUP_DESERT);
+          world(x + j, y + i)->flags |= FLAG_INVISIBLE; // hide maptiles
+        }
+        else {
+          world(x + j, y + i)->flags &= ~FLAG_INVISIBLE; // show maptiles
+          if(world(x + j, y + i)->group != GROUP_DESERT)
+            world(x + j, y + i)->setTerrain(GROUP_BARE);
+        }
+      }
+      assert(!world(x+j, y+i)->reportingConstruction);
+      world(x + j, y + i)->reportingConstruction = this;
+    } //endfor j
+  }// endfor i
+  world(x, y)->construction = this;
+  constructionCount.add_construction(this); //register for Simulation
+
+  //now look for neighbors
+  neighborize();
 }
 
 //use this before deleting a construction. Construction requests check independently against NULL
@@ -1492,47 +1533,10 @@ int ConstructionGroup::placeItem(int x, int y)
         std::cout << "failed to create " << name << " at " << "(" << x << ", " << y << ")" << std::endl;
         return -1;
     }
-     //default resources if no manual settings for construction
-    if (!tmpConstr->soundGroup)
-    {
-        std::cout << "Warning no explicit sound, graphics resources specified for "
-        << name << " at " << "(" << x << ", " << y << ")" << std::endl;
-        tmpConstr->init_resources();
-    }
 #endif
 
+    tmpConstr->place();
 
-    for (unsigned short i = 0; i < size; i++)
-    {
-        for (unsigned short j = 0; j < size; j++)
-        {
-            //never change water upon building something
-            if ( !world(x + j, y + i)->is_water() )
-            {
-                if( !(tmpConstr->flags & FLAG_TRANSPARENT))
-                {
-                    world(x + j, y + i)->setTerrain(GROUP_DESERT);
-                    world(x + j, y + i)->flags |= FLAG_INVISIBLE; //hide maptiles
-                }
-                else
-                {
-                    world(x + j, y + i)->flags &= (~FLAG_INVISIBLE); //always show maptiles
-                    if (world(x + j, y + i)->group != GROUP_DESERT)
-                    {   world(x + j, y + i)->setTerrain(GROUP_BARE);}
-                }
-            }
-            world(x + j, y + i)->reportingConstruction = tmpConstr;
-        } //endfor j
-    }// endfor i
-    world(x, y)->construction = tmpConstr;
-    constructionCount.add_construction(tmpConstr); //register for Simulation
-
-    //now look for neighbors
-    //skip ghosts (aka burning waste) and powerlines here
-    if(!(tmpConstr->flags & FLAG_IS_GHOST)
-    && (tmpConstr->constructionGroup->group != GROUP_FIRE)
-    && (tmpConstr->constructionGroup->group != GROUP_POWER_LINE)    )
-    {   tmpConstr->neighborize();}
     return 0;
 }
 

--- a/src/lincity/lintypes.cpp
+++ b/src/lincity/lintypes.cpp
@@ -453,9 +453,11 @@ void Construction::list_commodities(int *i) {
     switch(mps_map_page) {
     default:
     case 0:
+        mps_store_title((*i)++, _("Inventory:"));
         list_inventory(i);
         break;
     case 1:
+        mps_store_title((*i)++, _("Production:"));
         list_production(i);
         break;
     }

--- a/src/lincity/lintypes.cpp
+++ b/src/lincity/lintypes.cpp
@@ -581,6 +581,26 @@ void Construction::reset_prod_counters(void) {
     for(Commodity stuff = STUFF_INIT ; stuff < STUFF_COUNT; stuff++) {
         commodityProdPrev[stuff] = commodityProd[stuff];
         commodityProd[stuff] = 0;
+#if DEBUG
+    if(commodityProdPrev[stuff] > commodityMaxProd[stuff]) {
+        commodityMaxProd[stuff] = commodityProdPrev[stuff];
+        std::cerr << "error (non-fatal):"
+          << " construction "
+          << constructionGroup->name
+          << " exceeded maximum production of commodity "
+          << commodityNames[stuff]
+          << ". Updating maximum production." << '\n';
+    }
+    if(-commodityProdPrev[stuff] > commodityMaxCons[stuff]) {
+        commodityMaxCons[stuff] = -commodityProdPrev[stuff];
+        std::cerr << "error (non-fatal):"
+          << " construction "
+          << constructionGroup->name
+          << " exceeded maximum consumption of commodity "
+          << commodityNames[stuff]
+          << ". Updating maximum consumption." << '\n';
+    }
+#endif
     } //endfor
 }
 
@@ -608,8 +628,12 @@ void Construction::initialize_commodities(void)
     for(Commodity stuff = STUFF_INIT; stuff < STUFF_COUNT; stuff++)
     {
         commodityCount[stuff] = 0;
-        if(!constructionGroup->commodityRuleCount[stuff].maxload) continue;
-        setMemberSaved(&commodityCount[stuff], commodityNames[stuff]);
+        if(constructionGroup->commodityRuleCount[stuff].maxload)
+          setMemberSaved(&commodityCount[stuff], commodityNames[stuff]);
+        commodityProd[stuff] = 0;
+        commodityProdPrev[stuff] = 0;
+        commodityMaxProd[stuff] = 0;
+        commodityMaxCons[stuff] = 0;
     }
 }
 

--- a/src/lincity/lintypes.h
+++ b/src/lincity/lintypes.h
@@ -210,6 +210,7 @@ public:
     virtual void update() = 0;
     virtual void report() = 0;
     virtual void animate() {};
+    virtual void initialize() {};
 
 
     ConstructionGroup *constructionGroup;
@@ -264,6 +265,7 @@ public:
     void setCommodityRulesSaved(std::array<CommodityRule,STUFF_COUNT> * stuffRuleCount);
     void writeTemplate();      //create xml template for savegame
     void saveMembers(std::ostream *os);        //writes all needed and optionally set Members as XML to stream
+    virtual void place();
     void detach();      //removes all references from world, ::constructionCount
     void deneighborize(); //cancells all neighbors and partners mutually
     void   neighborize(); //adds all neigborconnections once (call twice for double connections)

--- a/src/lincity/lintypes.h
+++ b/src/lincity/lintypes.h
@@ -206,6 +206,18 @@ struct CommodityRule{
 
 class Construction {
 public:
+    Construction() {
+        for(Commodity stuff = STUFF_INIT; stuff < STUFF_COUNT; stuff++)
+        {
+            commodityCount[stuff] = 0;
+            // if(constructionGroup->commodityRuleCount[stuff].maxload)
+            //   setMemberSaved(&commodityCount[stuff], commodityNames[stuff]);
+            commodityProd[stuff] = 0;
+            commodityProdPrev[stuff] = 0;
+            commodityMaxProd[stuff] = 0;
+            commodityMaxCons[stuff] = 0;
+        }
+    }
     virtual ~Construction() {}
     virtual void update() = 0;
     virtual void report() = 0;

--- a/src/lincity/lintypes.h
+++ b/src/lincity/lintypes.h
@@ -380,7 +380,7 @@ public:
         unsigned short group,
         unsigned short size, int colour,
         int cost_mul, int bul_cost, int fire_chance,
-        int cost, int tech, int range
+        int cost, int tech, int range, int mps_pages
     ) {
         this->name = name;
         this->no_credit = no_credit;
@@ -395,6 +395,7 @@ public:
         this->range = range;
         //this->images_loaded = false;
         //this->sounds_loaded = false;
+        this->mps_pages = mps_pages;
 
         for(Commodity stuff = STUFF_INIT; stuff < STUFF_COUNT; stuff++) {
           this->commodityRuleCount[stuff] = (CommodityRule){
@@ -449,6 +450,7 @@ public:
     int range;                  /* range beyond size*/
     //bool images_loaded;
     //bool sounds_loaded;
+    int mps_pages;
 
     static void addConstructionGroup(ConstructionGroup *constructionGroup)
     {

--- a/src/lincity/lintypes.h
+++ b/src/lincity/lintypes.h
@@ -231,11 +231,11 @@ public:
     };
 
     // std::map<Commodities, int> commodityCount;  //map that holds all kinds of stuff
-    std::array<int, STUFF_COUNT> commodityCount;
-    std::array<int, STUFF_COUNT> commodityProd;
-    std::array<int, STUFF_COUNT> commodityProdPrev;
-    std::array<int, STUFF_COUNT> commodityMaxProd;
-    std::array<int, STUFF_COUNT> commodityMaxCons; // max consumption
+    std::array<int, STUFF_COUNT> commodityCount;    // inventory
+    std::array<int, STUFF_COUNT> commodityProd;     // production month-to-date
+    std::array<int, STUFF_COUNT> commodityProdPrev; // production last month
+    std::array<int, STUFF_COUNT> commodityMaxProd;  // max production
+    std::array<int, STUFF_COUNT> commodityMaxCons;  // max consumption
     std::map<std::string, MemberRule> memberRuleCount; //what to do with stuff at this construction
     std::vector<Construction*> neighbors;       //adjacent for transport
     std::vector<Construction*> partners;        //remotely for markets
@@ -246,9 +246,9 @@ public:
     void list_inventory(int *);                     // prints list of commodity inventory in report()
     void list_production(int *);                    // prints list of commodity production in report()
     void reset_prod_counters(void);                 // monthly update to production counters
-    int produceStuff(Commodity stuff_id, int amt); // increases inventory by amt and updates production counter
-    int consumeStuff(Commodity stuff_id, int amt); // decreases inventory by amt and updates production counter
-    int levelStuff(Commodity stuff_id, int amt);   // sets inventory level and updates production counter
+    int produceStuff(Commodity stuff_id, int amt);  // increases inventory by amt and updates production counter
+    int consumeStuff(Commodity stuff_id, int amt);  // decreases inventory by amt and updates production counter
+    int levelStuff(Commodity stuff_id, int amt);    // sets inventory level and updates production counter
     void report_commodities(void);                  //adds commodities and capacities to gloabl stat counter
     void initialize_commodities(void);              //sets all commodities to 0 and marks them as saved members
     void bootstrap_commodities(int percentage);     // sets all commodities except STUFF_WASTE to percentage.

--- a/src/lincity/lintypes.h
+++ b/src/lincity/lintypes.h
@@ -232,6 +232,10 @@ public:
 
     // std::map<Commodities, int> commodityCount;  //map that holds all kinds of stuff
     std::array<int, STUFF_COUNT> commodityCount;
+    std::array<int, STUFF_COUNT> commodityProd;
+    std::array<int, STUFF_COUNT> commodityProdPrev;
+    std::array<int, STUFF_COUNT> commodityMaxProd;
+    std::array<int, STUFF_COUNT> commodityMaxCons; // max consumption
     std::map<std::string, MemberRule> memberRuleCount; //what to do with stuff at this construction
     std::vector<Construction*> neighbors;       //adjacent for transport
     std::vector<Construction*> partners;        //remotely for markets
@@ -239,6 +243,12 @@ public:
     static std::string getStuffName(Commodity stuff_id); //translated name of a commodity
     void init_resources(void);                      //sets sounds and graphics according to constructionGroup
     void list_commodities(int *);                   //prints a sorted list all commodities in report()
+    void list_inventory(int *);                     // prints list of commodity inventory in report()
+    void list_production(int *);                    // prints list of commodity production in report()
+    void reset_prod_counters(void);                 // monthly update to production counters
+    int produceStuff(Commodity stuff_id, int amt); // increases inventory by amt and updates production counter
+    int consumeStuff(Commodity stuff_id, int amt); // decreases inventory by amt and updates production counter
+    int levelStuff(Commodity stuff_id, int amt);   // sets inventory level and updates production counter
     void report_commodities(void);                  //adds commodities and capacities to gloabl stat counter
     void initialize_commodities(void);              //sets all commodities to 0 and marks them as saved members
     void bootstrap_commodities(int percentage);     // sets all commodities except STUFF_WASTE to percentage.

--- a/src/lincity/modules/blacksmith.cpp
+++ b/src/lincity/modules/blacksmith.cpp
@@ -27,12 +27,6 @@ Construction *BlacksmithConstructionGroup::createConstruction(int x, int y) {
 
 void Blacksmith::update()
 {
-    //monthly update
-    if (total_time % 100 == 0)
-    {
-        busy = working_days;
-        working_days = 0;
-    }
     if (pauseCounter++ < 0)
     {   return;}
     if ((commodityCount[STUFF_GOODS] + GOODS_MADE_BY_BLACKSMITH <= MAX_GOODS_AT_BLACKSMITH )
@@ -40,10 +34,10 @@ void Blacksmith::update()
         && (commodityCount[STUFF_STEEL] >= BLACKSMITH_STEEL_USED)
         && (commodityCount[STUFF_JOBS] >= BLACKSMITH_JOBS))
     {
-        commodityCount[STUFF_GOODS] += GOODS_MADE_BY_BLACKSMITH;
-        commodityCount[STUFF_COAL] -= BLACKSMITH_COAL_USED;
-        commodityCount[STUFF_STEEL] -= BLACKSMITH_STEEL_USED;
-        commodityCount[STUFF_JOBS] -= BLACKSMITH_JOBS;
+        produceStuff(STUFF_GOODS, GOODS_MADE_BY_BLACKSMITH);
+        consumeStuff(STUFF_COAL, BLACKSMITH_COAL_USED);
+        consumeStuff(STUFF_STEEL, BLACKSMITH_STEEL_USED);
+        consumeStuff(STUFF_JOBS, BLACKSMITH_JOBS);
         working_days++;
         if ((goods_made += GOODS_MADE_BY_BLACKSMITH) >= BLACKSMITH_BATCH)
         {
@@ -57,6 +51,13 @@ void Blacksmith::update()
         animate_enable = false;
         pauseCounter = -BLACKSMITH_CLOSE_TIME;
         return;
+    }
+
+    //monthly update
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
+        busy = working_days;
+        working_days = 0;
     }
 }
 

--- a/src/lincity/modules/blacksmith.cpp
+++ b/src/lincity/modules/blacksmith.cpp
@@ -83,7 +83,7 @@ void Blacksmith::report()
     mps_store_sd(i++, constructionGroup->name, ID);
     i++;
     mps_store_sfp(i++, N_("busy"), (float) busy);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/blacksmith.h
+++ b/src/lincity/modules/blacksmith.h
@@ -72,6 +72,11 @@ public:
         this->animate_enable = false;
         this->goods_made = 0;
         initialize_commodities();
+
+        commodityMaxProd[STUFF_GOODS] = 100 * GOODS_MADE_BY_BLACKSMITH;
+        commodityMaxCons[STUFF_COAL] = 100 * BLACKSMITH_COAL_USED;
+        commodityMaxCons[STUFF_STEEL] = 100 * BLACKSMITH_STEEL_USED;
+        commodityMaxCons[STUFF_JOBS] = 100 * BLACKSMITH_JOBS;
     }
     virtual ~Blacksmith() { }
     virtual void update() override;

--- a/src/lincity/modules/blacksmith.h
+++ b/src/lincity/modules/blacksmith.h
@@ -36,7 +36,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_BLACKSMITH;

--- a/src/lincity/modules/coal_power.cpp
+++ b/src/lincity/modules/coal_power.cpp
@@ -40,15 +40,15 @@ void Coal_power::update()
      && (commodityCount[STUFF_COAL] >= coal_used)
      && (mwh_made >= POWERS_COAL_OUTPUT))
     {
-        commodityCount[STUFF_JOBS] -= jobs_used;
-        commodityCount[STUFF_COAL] -= coal_used;
-        commodityCount[STUFF_MWH] += mwh_made;
+        consumeStuff(STUFF_JOBS, jobs_used);
+        consumeStuff(STUFF_COAL, coal_used);
+        produceStuff(STUFF_MWH, mwh_made);
         world(x,y)->pollution += POWERS_COAL_POLLUTION *(mwh_made/100)/(mwh_output/100);
         working_days += (mwh_made/100);
     }
     //monthly update
-    if (total_time % 100 == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         busy = working_days / (mwh_output/100);
         working_days = 0;
     }

--- a/src/lincity/modules/coal_power.cpp
+++ b/src/lincity/modules/coal_power.cpp
@@ -93,7 +93,7 @@ void Coal_power::report()
     mps_store_sfp(i++, N_("busy"), busy);
     mps_store_sfp(i++, N_("Tech"), (float)(tech * 100.0) / MAX_TECH_LEVEL);
     mps_store_sd(i++, N_("Output"), mwh_output);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/coal_power.h
+++ b/src/lincity/modules/coal_power.h
@@ -100,16 +100,24 @@ public:
         setMemberSaved(&this->tech, "tech");
         this->working_days = 0;
         this->busy = 0;
-        this->mwh_output = (int)(POWERS_COAL_OUTPUT + (((double)tech_level * POWERS_COAL_OUTPUT) / MAX_TECH_LEVEL));
-        setMemberSaved(&this->mwh_output, "mwh_output");
+        // this->mwh_output = (int)(POWERS_COAL_OUTPUT + (((double)tech_level * POWERS_COAL_OUTPUT) / MAX_TECH_LEVEL));
+        setMemberSaved(&this->mwh_output, "mwh_output"); // compatibility
         initialize_commodities();
 
         commodityMaxCons[STUFF_JOBS] = 100 * JOBS_COALPS_GENERATE;
         commodityMaxCons[STUFF_COAL] = 100 *
           (POWERS_COAL_OUTPUT / POWER_PER_COAL);
-        commodityMaxProd[STUFF_MWH] = 100 * mwh_output;
-        // TODO: update this after loading saved members
+        // commodityMaxProd[STUFF_MWH] = 100 * mwh_output;
     }
+
+    virtual void initialize() override {
+        RegisteredConstruction::initialize();
+
+        this->mwh_output = (int)(POWERS_COAL_OUTPUT +
+          (((double)tech_level * POWERS_COAL_OUTPUT) / MAX_TECH_LEVEL));
+        commodityMaxProd[STUFF_MWH] = 100 * mwh_output;
+    }
+
     virtual ~Coal_power() //remove 2 or more extraframes
     {
         if(world(x,y)->framesptr)
@@ -122,6 +130,7 @@ public:
             }
         }
     }
+
     virtual void update() override;
     virtual void report() override;
     virtual void animate() override;

--- a/src/lincity/modules/coal_power.h
+++ b/src/lincity/modules/coal_power.h
@@ -103,6 +103,11 @@ public:
         this->mwh_output = (int)(POWERS_COAL_OUTPUT + (((double)tech_level * POWERS_COAL_OUTPUT) / MAX_TECH_LEVEL));
         setMemberSaved(&this->mwh_output, "mwh_output");
         initialize_commodities();
+
+        commodityMaxCons[STUFF_JOBS] = JOBS_COALPS_GENERATE;
+        commodityMaxCons[STUFF_COAL] = POWERS_COAL_OUTPUT / POWER_PER_COAL;
+        commodityMaxProd[STUFF_MWH] = mwh_output;
+        // TODO: update this after loading saved members
     }
     virtual ~Coal_power() //remove 2 or more extraframes
     {

--- a/src/lincity/modules/coal_power.h
+++ b/src/lincity/modules/coal_power.h
@@ -32,7 +32,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_COALPS;
         commodityRuleCount[STUFF_JOBS].take = true;

--- a/src/lincity/modules/coal_power.h
+++ b/src/lincity/modules/coal_power.h
@@ -104,9 +104,10 @@ public:
         setMemberSaved(&this->mwh_output, "mwh_output");
         initialize_commodities();
 
-        commodityMaxCons[STUFF_JOBS] = JOBS_COALPS_GENERATE;
-        commodityMaxCons[STUFF_COAL] = POWERS_COAL_OUTPUT / POWER_PER_COAL;
-        commodityMaxProd[STUFF_MWH] = mwh_output;
+        commodityMaxCons[STUFF_JOBS] = 100 * JOBS_COALPS_GENERATE;
+        commodityMaxCons[STUFF_COAL] = 100 *
+          (POWERS_COAL_OUTPUT / POWER_PER_COAL);
+        commodityMaxProd[STUFF_MWH] = 100 * mwh_output;
         // TODO: update this after loading saved members
     }
     virtual ~Coal_power() //remove 2 or more extraframes

--- a/src/lincity/modules/coalmine.cpp
+++ b/src/lincity/modules/coalmine.cpp
@@ -124,7 +124,7 @@ void Coalmine::report()
     mps_store_sd(i++, constructionGroup->name, ID);
     mps_store_sfp(i++, N_("busy"), busy);
     mps_store_sddp(i++, N_("Deposits"), current_coal_reserve, initial_coal_reserve);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/coalmine.cpp
+++ b/src/lincity/modules/coalmine.cpp
@@ -56,8 +56,8 @@ void Coalmine::update()
                     world(xx,yy)->coal_reserve--;
                     world(xx,yy)->pollution += COALMINE_POLLUTION;
                     world(xx,yy)->flags |= FLAG_ALTERED;
-                    commodityCount[STUFF_COAL] += COAL_PER_RESERVE;
-                    commodityCount[STUFF_JOBS] -= COALMINE_JOBS;
+                    produceStuff(STUFF_COAL, COAL_PER_RESERVE);
+                    consumeStuff(STUFF_JOBS, COALMINE_JOBS);
                     if (current_coal_reserve < initial_coal_reserve)
                     {   sust_dig_ore_coal_tip_flag = 0;}
                     coal_found = true;
@@ -77,8 +77,8 @@ void Coalmine::update()
                 {
                     world(xx,yy)->coal_reserve++;
                     world(xx,yy)->flags |= FLAG_ALTERED;
-                    commodityCount[STUFF_COAL] -= COAL_PER_RESERVE;
-                    commodityCount[STUFF_JOBS] -= COALMINE_JOBS;
+                    consumeStuff(STUFF_COAL, COAL_PER_RESERVE);
+                    consumeStuff(STUFF_JOBS, COALMINE_JOBS);
                     coal_found = true;
                     working_days++;
                 }
@@ -86,8 +86,8 @@ void Coalmine::update()
         }
     }
     //Monthly update of activity
-    if (total_time % 100 == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/coalmine.h
+++ b/src/lincity/modules/coalmine.h
@@ -91,6 +91,10 @@ public:
         this->initial_coal_reserve = coal;
         setMemberSaved(&this->initial_coal_reserve,"initial_coal_reserve");
         this->current_coal_reserve = coal;
+
+        commodityMaxProd[STUFF_COAL] = 100 * COAL_PER_RESERVE;
+        commodityMaxCons[STUFF_COAL] = 100 * COAL_PER_RESERVE;
+        commodityMaxCons[STUFF_JOBS] = 100 * COALMINE_JOBS;
     }
     virtual ~Coalmine() { }
     virtual void update() override;

--- a/src/lincity/modules/coalmine.h
+++ b/src/lincity/modules/coalmine.h
@@ -34,7 +34,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_COALMINE;
         commodityRuleCount[STUFF_JOBS].take = true;

--- a/src/lincity/modules/commune.cpp
+++ b/src/lincity/modules/commune.cpp
@@ -35,26 +35,26 @@ void Commune::update()
     {
         tmpUgwCount = a;
         tmpCoalprod = COMMUNE_COAL_MADE;
-        commodityCount[STUFF_WATER] -= (a-ugwCount)*WATER_FOREST;
+        consumeStuff(STUFF_WATER, (a-ugwCount)*WATER_FOREST);
     }
     if(//(total_time & 1) && //make coal every second day
        (tmpCoalprod > 0)
     && (commodityCount[STUFF_COAL] + tmpCoalprod <= MAX_COAL_AT_COMMUNE ))
     {
-         commodityCount[STUFF_COAL] += tmpCoalprod;
+         produceStuff(STUFF_COAL, tmpCoalprod);
          monthly_stuff_made++;
          animate_enable = true;
     }
     if(commodityCount[STUFF_ORE] + COMMUNE_ORE_MADE <= MAX_ORE_AT_COMMUNE)
     {
-        commodityCount[STUFF_ORE] += COMMUNE_ORE_MADE;
+        produceStuff(STUFF_ORE, COMMUNE_ORE_MADE);
         monthly_stuff_made++;
         animate_enable = true;
     }
     /* recycle a bit of waste if there is plenty*/
     if (commodityCount[STUFF_WASTE] >= 3 * COMMUNE_WASTE_GET)
     {
-        commodityCount[STUFF_WASTE] -= COMMUNE_WASTE_GET;
+        consumeStuff(STUFF_WASTE, COMMUNE_WASTE_GET);
         monthly_stuff_made++;
         animate_enable = true;
         if(commodityCount[STUFF_ORE] + COMMUNE_ORE_FROM_WASTE <= MAX_ORE_AT_COMMUNE )
@@ -75,12 +75,12 @@ void Commune::update()
             monthly_stuff_made++;
             animate_enable = true;
             steel_made = true;
-            commodityCount[STUFF_STEEL] += COMMUNE_STEEL_MADE;
+            produceStuff(STUFF_STEEL, COMMUNE_STEEL_MADE);
         }
     }
 
-    if (total_time % 100 == 1)
-    {//each month
+    if (total_time % 100 == 99) { //each month
+        reset_prod_counters();
         last_month_output = monthly_stuff_made;
         monthly_stuff_made = 0;
         if (last_month_output)
@@ -92,8 +92,10 @@ void Commune::update()
         {//we are lazy
             lazy_months++;
             /* Communes without production only last 10 years */
-            if (lazy_months > 120)
-            {   ConstructionManager::submitRequest(new CommuneDeletionRequest(this));}
+            if (lazy_months > 120) {
+                ConstructionManager::submitRequest(new CommuneDeletionRequest(this));
+                return;
+            }
         }//end we are lazy
     }//end each month
 }

--- a/src/lincity/modules/commune.h
+++ b/src/lincity/modules/commune.h
@@ -95,6 +95,13 @@ public:
         {   this->coalprod = COMMUNE_COAL_MADE/2;}
         else
         {   this->coalprod = COMMUNE_COAL_MADE;}
+
+        commodityMaxCons[STUFF_WATER] = 100 *
+          constructionGroup->size * constructionGroup->size * WATER_FOREST;
+        commodityMaxProd[STUFF_COAL] = 100 * COMMUNE_COAL_MADE;
+        commodityMaxProd[STUFF_ORE] = 100 * COMMUNE_ORE_MADE;
+        commodityMaxCons[STUFF_WASTE] = 100 * COMMUNE_WASTE_GET;
+        commodityMaxProd[STUFF_STEEL] = 100 / 20 * COMMUNE_STEEL_MADE;
     }
     virtual ~Commune() { }
     virtual void update() override;

--- a/src/lincity/modules/commune.h
+++ b/src/lincity/modules/commune.h
@@ -39,7 +39,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_COAL].maxload = MAX_COAL_AT_COMMUNE;

--- a/src/lincity/modules/cricket.cpp
+++ b/src/lincity/modules/cricket.cpp
@@ -90,7 +90,7 @@ void Cricket::report()
 
     mps_store_sd(i++,constructionGroup->name, ID);
     mps_store_sfp(i++, N_("busy"), busy);
-    i++;
+    // i++;
     list_commodities(&i);
     p = active?N_("Yes"):N_("No");
     mps_store_ss(i++, N_("Public sports"), p);

--- a/src/lincity/modules/cricket.cpp
+++ b/src/lincity/modules/cricket.cpp
@@ -34,15 +34,15 @@ void Cricket::update()
     &&  commodityCount[STUFF_GOODS] >= CRICKET_GOODS
     &&  commodityCount[STUFF_WASTE] + (CRICKET_GOODS / 3) <= MAX_WASTE_AT_CRICKET)
     {
-        commodityCount[STUFF_JOBS] -= CRICKET_JOBS;
-        commodityCount[STUFF_GOODS] -= CRICKET_GOODS;
-        commodityCount[STUFF_WASTE] += (CRICKET_GOODS / 3);
+        consumeStuff(STUFF_JOBS, CRICKET_JOBS);
+        consumeStuff(STUFF_GOODS, CRICKET_GOODS);
+        produceStuff(STUFF_WASTE, CRICKET_GOODS / 3);
         ++covercount;
         ++working_days;
     }
     //monthly update
-    if (total_time % 100 == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/cricket.h
+++ b/src/lincity/modules/cricket.h
@@ -78,6 +78,10 @@ public:
         this->xe = (tmp > lenm1) ? lenm1 : tmp;
         tmp = y + constructionGroup->range + constructionGroup->size;
         this->ye = (tmp > lenm1)? lenm1 : tmp;
+
+        commodityMaxCons[STUFF_JOBS] = 100 * CRICKET_JOBS;
+        commodityMaxCons[STUFF_GOODS] = 100 * CRICKET_GOODS;
+        commodityMaxProd[STUFF_WASTE] = 100 * (CRICKET_GOODS / 3);
     }
 
     virtual ~Cricket() { }

--- a/src/lincity/modules/cricket.h
+++ b/src/lincity/modules/cricket.h
@@ -1,3 +1,8 @@
+
+#ifndef __cricket_h__
+#define __cricket_h__
+
+
 #define GROUP_CRICKET_COLOUR (white(20))
 #define GROUP_CRICKET_COST   2000
 #define GROUP_CRICKET_COST_MUL 3
@@ -97,4 +102,5 @@ public:
     int working_days, busy;
 };
 
+#endif /* __cricket_h__ */
 /** @file lincity/modules/cricket.h */

--- a/src/lincity/modules/cricket.h
+++ b/src/lincity/modules/cricket.h
@@ -31,7 +31,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_CRICKET;
         commodityRuleCount[STUFF_JOBS].take = true;

--- a/src/lincity/modules/fire.h
+++ b/src/lincity/modules/fire.h
@@ -29,7 +29,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 1/*mps_pages*/
     ) {
 
     };

--- a/src/lincity/modules/firestation.cpp
+++ b/src/lincity/modules/firestation.cpp
@@ -35,15 +35,15 @@ void FireStation::update()
     &&  commodityCount[STUFF_GOODS] >= FIRESTATION_GOODS
     &&  commodityCount[STUFF_WASTE] + (FIRESTATION_GOODS / 3) <= MAX_WASTE_AT_FIRESTATION)
     {
-        commodityCount[STUFF_JOBS] -= FIRESTATION_JOBS;
-        commodityCount[STUFF_GOODS] -= FIRESTATION_GOODS;
-        commodityCount[STUFF_WASTE] += (FIRESTATION_GOODS / 3);
+        consumeStuff(STUFF_JOBS, FIRESTATION_JOBS);
+        consumeStuff(STUFF_GOODS, FIRESTATION_GOODS);
+        produceStuff(STUFF_WASTE, FIRESTATION_GOODS / 3);
         ++covercount;
         ++working_days;
     }
     //monthly update
-    if (total_time % 100 == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/firestation.cpp
+++ b/src/lincity/modules/firestation.cpp
@@ -91,7 +91,7 @@ void FireStation::report()
     const char* p;
     mps_store_sd(i++, constructionGroup->name, ID);
     mps_store_sfp(i++, N_("busy"), (float) busy);
-    i++;
+    // i++;
     list_commodities(&i);
     p = active?N_("Yes"):N_("No");
     mps_store_ss(i++, N_("Fire Protection"), p);

--- a/src/lincity/modules/firestation.h
+++ b/src/lincity/modules/firestation.h
@@ -30,7 +30,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_FIRESTATION;

--- a/src/lincity/modules/firestation.h
+++ b/src/lincity/modules/firestation.h
@@ -78,6 +78,11 @@ public:
         this->xe = (tmp > lenm1) ? lenm1 : tmp;
         tmp = y + constructionGroup->range + constructionGroup->size;
         this->ye = (tmp > lenm1)? lenm1 : tmp;
+
+        commodityMaxCons[STUFF_JOBS] = 100 * FIRESTATION_JOBS;
+        commodityMaxCons[STUFF_GOODS] = 100 * FIRESTATION_GOODS;
+        commodityMaxProd[STUFF_WASTE] = 100 * (FIRESTATION_GOODS / 3);
+
     }
     virtual ~FireStation() { }
     virtual void update() override;

--- a/src/lincity/modules/health_centre.cpp
+++ b/src/lincity/modules/health_centre.cpp
@@ -33,15 +33,15 @@ void HealthCentre::update()
     &&  commodityCount[STUFF_GOODS] >= HEALTH_CENTRE_GOODS
     &&  commodityCount[STUFF_WASTE] + (HEALTH_CENTRE_GOODS / 3) <= MAX_WASTE_AT_HEALTH_CENTRE)
     {
-        commodityCount[STUFF_JOBS] -= HEALTH_CENTRE_JOBS;
-        commodityCount[STUFF_GOODS] -= HEALTH_CENTRE_GOODS;
-        commodityCount[STUFF_WASTE] += (HEALTH_CENTRE_GOODS / 3);
+        consumeStuff(STUFF_JOBS, HEALTH_CENTRE_JOBS);
+        consumeStuff(STUFF_GOODS, HEALTH_CENTRE_GOODS);
+        produceStuff(STUFF_WASTE, HEALTH_CENTRE_GOODS / 3);
         ++covercount;
         ++working_days;
     }
     //monthly update
-    if (total_time % 100 == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }
@@ -83,4 +83,3 @@ void HealthCentre::report() {
 }
 
 /** @file lincity/modules/health_centre.cpp */
-

--- a/src/lincity/modules/health_centre.cpp
+++ b/src/lincity/modules/health_centre.cpp
@@ -76,7 +76,7 @@ void HealthCentre::report() {
 
     mps_store_sd(i++, constructionGroup->name, ID);
     mps_store_sfp(i++, N_("busy"), (float) busy);
-    i++;
+    // i++;
     list_commodities(&i);
     p = active?_("Yes"):_("No");
     mps_store_ss(i++, N_("Health Care"), p);

--- a/src/lincity/modules/health_centre.h
+++ b/src/lincity/modules/health_centre.h
@@ -74,6 +74,10 @@ public:
         this->xe = (tmp > lenm1) ? lenm1 : tmp;
         tmp = y + constructionGroup->range + constructionGroup->size;
         this->ye = (tmp > lenm1)? lenm1 : tmp;
+
+        commodityMaxCons[STUFF_JOBS] = 100 * HEALTH_CENTRE_JOBS;
+        commodityMaxCons[STUFF_GOODS] = 100 * HEALTH_CENTRE_GOODS;
+        commodityMaxProd[STUFF_WASTE] = 100 * (HEALTH_CENTRE_GOODS / 3);
     }
     virtual ~HealthCentre() { }
     virtual void update();

--- a/src/lincity/modules/health_centre.h
+++ b/src/lincity/modules/health_centre.h
@@ -29,7 +29,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_HEALTH_CENTRE;
         commodityRuleCount[STUFF_JOBS].take = true;
@@ -86,4 +87,3 @@ public:
 };
 
 /** @file lincity/modules/health_centre.h */
-

--- a/src/lincity/modules/heavy_industry.cpp
+++ b/src/lincity/modules/heavy_industry.cpp
@@ -137,7 +137,7 @@ void IndustryHeavy::report()
     i++;
     mps_store_sfp(i++, N_("busy"), (output_level));
     mps_store_sfp(i++, N_("Tech"), (tech * 100.0) / MAX_TECH_LEVEL);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/heavy_industry.cpp
+++ b/src/lincity/modules/heavy_industry.cpp
@@ -68,12 +68,12 @@ void IndustryHeavy::update()
         }//end Second
         if (powered_steel == steel)
         {
-            commodityCount[STUFF_MWH] -= used_MWH;
-            commodityCount[STUFF_KWH] -= used_KWH;
+            consumeStuff(STUFF_MWH, used_MWH);
+            consumeStuff(STUFF_KWH, used_KWH);
             if(used_COAL)// coal power is more laborous
             {
-                commodityCount[STUFF_COAL] -= used_COAL;
-                commodityCount[STUFF_JOBS] -= JOBS_LOAD_COAL;
+                consumeStuff(STUFF_COAL, used_COAL);
+                consumeStuff(STUFF_JOBS, JOBS_LOAD_COAL);
             }
         }
         else
@@ -81,29 +81,29 @@ void IndustryHeavy::update()
 
         if (steel>0)
         {
-            commodityCount[STUFF_JOBS] -= (MAX_ORE_USED / JOBS_MAKE_STEEL);
+            consumeStuff(STUFF_JOBS, MAX_ORE_USED / JOBS_MAKE_STEEL);
             //use jobs for loading the ore
-            commodityCount[STUFF_JOBS] -= JOBS_LOAD_ORE;
+            consumeStuff(STUFF_JOBS, JOBS_LOAD_ORE);
             //use jobs for loading the steel
-            commodityCount[STUFF_JOBS] -= JOBS_LOAD_STEEL;
-            commodityCount[STUFF_ORE] -= MAX_ORE_USED;
-            commodityCount[STUFF_STEEL] += steel;
+            consumeStuff(STUFF_JOBS, JOBS_LOAD_STEEL);
+            consumeStuff(STUFF_ORE, MAX_ORE_USED);
+            produceStuff(STUFF_STEEL, steel);
             steel_this_month += steel;
             //cause some pollution and waste depending on bonuses
             world(x,y)->pollution += (int)(((double)(POL_PER_STEEL_MADE * steel) * (1 - bonus)));
-            commodityCount[STUFF_WASTE] += (int)(((double)(POL_PER_STEEL_MADE * steel) * bonus)*(1-extra_bonus));
+            produceStuff(STUFF_WASTE, (int)(((double)(POL_PER_STEEL_MADE * steel) * bonus)*(1-extra_bonus)));
             // if the trash bin is full reburn the filterd pollution
             if (commodityCount[STUFF_WASTE] > MAX_WASTE_AT_INDUSTRY_H)
             {
                 world(x,y)->pollution += (commodityCount[STUFF_WASTE] - MAX_WASTE_AT_INDUSTRY_H);
-                commodityCount[STUFF_WASTE] = MAX_WASTE_AT_INDUSTRY_H;
+                levelStuff(STUFF_WASTE, MAX_WASTE_AT_INDUSTRY_H);
             }
         }//endif steel still > 0
     }//endif steel > 0
 
     //monthly update
-    if (total_time % 100 == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         output_level = steel_this_month * ORE_MAKE_STEEL / MAX_ORE_USED;
         steel_this_month = 0;
     }//end monthly update

--- a/src/lincity/modules/heavy_industry.h
+++ b/src/lincity/modules/heavy_industry.h
@@ -108,12 +108,12 @@ public:
         int steel_prod = MAX_ORE_USED / ORE_MAKE_STEEL;
         commodityMaxCons[STUFF_MWH] = 100 * (steel_prod * POWER_MAKE_STEEL / 2);
         commodityMaxCons[STUFF_KWH] = 100 * (steel_prod * POWER_MAKE_STEEL);
-        commodityMaxCons[STUFF_KWH] = 100 * (steel_prod * COAL_MAKE_STEEL);
+        commodityMaxCons[STUFF_COAL] = 100 * (steel_prod * COAL_MAKE_STEEL);
         commodityMaxCons[STUFF_JOBS] = 100 * (MAX_ORE_USED / JOBS_MAKE_STEEL +
           JOBS_LOAD_COAL + JOBS_LOAD_ORE + JOBS_LOAD_STEEL);
         commodityMaxCons[STUFF_ORE] = 100 * MAX_ORE_USED;
         commodityMaxProd[STUFF_STEEL] = 100 * steel_prod;
-        commodityMaxProd[STUFF_STEEL] = 100 * (int)(
+        commodityMaxProd[STUFF_WASTE] = 100 * (int)(
           ((double)(POL_PER_STEEL_MADE * steel_prod) * bonus)*(1-extra_bonus));
         // TODO: update after loading saved members
     }

--- a/src/lincity/modules/heavy_industry.h
+++ b/src/lincity/modules/heavy_industry.h
@@ -37,7 +37,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_INDUSTRY_H;

--- a/src/lincity/modules/heavy_industry.h
+++ b/src/lincity/modules/heavy_industry.h
@@ -104,6 +104,18 @@ public:
                 extra_bonus /= MAX_TECH_LEVEL;
             }
         }
+
+        int steel_prod = MAX_ORE_USED / ORE_MAKE_STEEL;
+        commodityMaxCons[STUFF_MWH] = 100 * (steel_prod * POWER_MAKE_STEEL / 2);
+        commodityMaxCons[STUFF_KWH] = 100 * (steel_prod * POWER_MAKE_STEEL);
+        commodityMaxCons[STUFF_KWH] = 100 * (steel_prod * COAL_MAKE_STEEL);
+        commodityMaxCons[STUFF_JOBS] = 100 * (MAX_ORE_USED / JOBS_MAKE_STEEL +
+          JOBS_LOAD_COAL + JOBS_LOAD_ORE + JOBS_LOAD_STEEL);
+        commodityMaxCons[STUFF_ORE] = 100 * MAX_ORE_USED;
+        commodityMaxProd[STUFF_STEEL] = 100 * steel_prod;
+        commodityMaxProd[STUFF_STEEL] = 100 * (int)(
+          ((double)(POL_PER_STEEL_MADE * steel_prod) * bonus)*(1-extra_bonus));
+        // TODO: update after loading saved members
     }
     virtual void update() override;
     virtual void report() override;

--- a/src/lincity/modules/heavy_industry.h
+++ b/src/lincity/modules/heavy_industry.h
@@ -86,9 +86,40 @@ public:
         initialize_commodities();
          //check for pollution bonus
         this->bonus = 0;
-        setMemberSaved(&this->bonus, "bonus");
+        setMemberSaved(&this->bonus, "bonus"); // compatibility
         this->extra_bonus = 0;
-        setMemberSaved(&this->extra_bonus, "extra_bonus");
+        setMemberSaved(&this->extra_bonus, "extra_bonus"); // compatibility
+        // if (tech > MAX_TECH_LEVEL)
+        // {
+        //     bonus = (tech - MAX_TECH_LEVEL);
+        //     if (bonus > MAX_TECH_LEVEL)
+        //         bonus = MAX_TECH_LEVEL;
+        //     bonus /= MAX_TECH_LEVEL;
+        //     // check for filter technology bonus
+        //     if (tech > 2 * MAX_TECH_LEVEL)
+        //     {
+        //         extra_bonus = tech - 2 * MAX_TECH_LEVEL;
+        //         if (extra_bonus > MAX_TECH_LEVEL)
+        //             extra_bonus = MAX_TECH_LEVEL;
+        //         extra_bonus /= MAX_TECH_LEVEL;
+        //     }
+        // }
+
+        int steel_prod = MAX_ORE_USED / ORE_MAKE_STEEL;
+        commodityMaxCons[STUFF_MWH] = 100 * (steel_prod * POWER_MAKE_STEEL / 2);
+        commodityMaxCons[STUFF_KWH] = 100 * (steel_prod * POWER_MAKE_STEEL);
+        commodityMaxCons[STUFF_COAL] = 100 * (steel_prod * COAL_MAKE_STEEL);
+        commodityMaxCons[STUFF_JOBS] = 100 * (MAX_ORE_USED / JOBS_MAKE_STEEL +
+          JOBS_LOAD_COAL + JOBS_LOAD_ORE + JOBS_LOAD_STEEL);
+        commodityMaxCons[STUFF_ORE] = 100 * MAX_ORE_USED;
+        commodityMaxProd[STUFF_STEEL] = 100 * steel_prod;
+        // commodityMaxProd[STUFF_WASTE] = 100 * (int)(
+        //   ((double)(POL_PER_STEEL_MADE * steel_prod) * bonus)*(1-extra_bonus));
+    }
+
+    virtual void initialize() override {
+        RegisteredConstruction::initialize();
+
         if (tech > MAX_TECH_LEVEL)
         {
             bonus = (tech - MAX_TECH_LEVEL);
@@ -106,17 +137,10 @@ public:
         }
 
         int steel_prod = MAX_ORE_USED / ORE_MAKE_STEEL;
-        commodityMaxCons[STUFF_MWH] = 100 * (steel_prod * POWER_MAKE_STEEL / 2);
-        commodityMaxCons[STUFF_KWH] = 100 * (steel_prod * POWER_MAKE_STEEL);
-        commodityMaxCons[STUFF_COAL] = 100 * (steel_prod * COAL_MAKE_STEEL);
-        commodityMaxCons[STUFF_JOBS] = 100 * (MAX_ORE_USED / JOBS_MAKE_STEEL +
-          JOBS_LOAD_COAL + JOBS_LOAD_ORE + JOBS_LOAD_STEEL);
-        commodityMaxCons[STUFF_ORE] = 100 * MAX_ORE_USED;
-        commodityMaxProd[STUFF_STEEL] = 100 * steel_prod;
         commodityMaxProd[STUFF_WASTE] = 100 * (int)(
           ((double)(POL_PER_STEEL_MADE * steel_prod) * bonus)*(1-extra_bonus));
-        // TODO: update after loading saved members
     }
+
     virtual void update() override;
     virtual void report() override;
     virtual void animate() override;

--- a/src/lincity/modules/light_industry.cpp
+++ b/src/lincity/modules/light_industry.cpp
@@ -158,7 +158,7 @@ void IndustryLight::report()
     i++;
     mps_store_sfp(i++, N_("busy"), (busy));
     mps_store_sfp(i++, N_("Tech"), (tech * 100.0) / MAX_TECH_LEVEL);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/light_industry.cpp
+++ b/src/lincity/modules/light_industry.cpp
@@ -35,6 +35,15 @@ Construction *IndustryLightConstructionGroup::createConstruction(int x, int y ) 
 
 void IndustryLight::update()
 {
+    //monthly update
+    if (total_time % 100 == 0)
+    {
+        reset_prod_counters();
+        int output_level = goods_this_month / (INDUSTRY_L_MAKE_GOODS * 8);
+        busy = output_level;
+        goods_this_month = 0;
+    }// end monthly update
+
     goods_today = 0;
 
     // make some goods with jobs and ore
@@ -42,25 +51,25 @@ void IndustryLight::update()
      && (commodityCount[STUFF_ORE] >= INDUSTRY_L_ORE_USED)
      && (commodityCount[STUFF_GOODS] + INDUSTRY_L_MAKE_GOODS <= MAX_GOODS_AT_INDUSTRY_L))
     {
-        commodityCount[STUFF_JOBS] -= (INDUSTRY_L_JOBS_USED + INDUSTRY_L_JOBS_LOAD_ORE + JOBS_LOAD_ORE);
-        commodityCount[STUFF_ORE] -= INDUSTRY_L_ORE_USED;
+        consumeStuff(STUFF_JOBS, INDUSTRY_L_JOBS_USED + INDUSTRY_L_JOBS_LOAD_ORE + JOBS_LOAD_ORE);
+        consumeStuff(STUFF_ORE, INDUSTRY_L_ORE_USED);
         goods_today = INDUSTRY_L_MAKE_GOODS;
         //make some pollution and waste
         world(x,y)->pollution += (int)(((double)(INDUSTRY_L_POL_PER_GOOD * goods_today) * (1 - bonus)));
-        commodityCount[STUFF_WASTE] += (int)(((double)(INDUSTRY_L_POL_PER_GOOD * goods_today) * bonus)*(1-extra_bonus));
+        produceStuff(STUFF_WASTE, (int)(((double)(INDUSTRY_L_POL_PER_GOOD * goods_today) * bonus)*(1-extra_bonus)));
         // if the trash bin is full reburn the filterd pollution
         if (commodityCount[STUFF_WASTE] > MAX_WASTE_AT_INDUSTRY_L)
-            {
-                world(x,y)->pollution += (commodityCount[STUFF_WASTE] - MAX_WASTE_AT_INDUSTRY_L);
-                commodityCount[STUFF_WASTE] = MAX_WASTE_AT_INDUSTRY_L;
-            }
+        {
+            int excess = -levelStuff(STUFF_WASTE, MAX_WASTE_AT_INDUSTRY_L);
+            world(x,y)->pollution += excess;
+        }
         //now double goods_today if there are more jobs and steel
         if ((commodityCount[STUFF_JOBS] >= (INDUSTRY_L_JOBS_LOAD_STEEL + JOBS_LOAD_STEEL))
          && (commodityCount[STUFF_STEEL] >= INDUSTRY_L_STEEL_USED )
         && (commodityCount[STUFF_GOODS] + 2 * goods_today <= MAX_GOODS_AT_INDUSTRY_L))
         {
-            commodityCount[STUFF_JOBS] -= (INDUSTRY_L_JOBS_LOAD_STEEL + JOBS_LOAD_STEEL);
-            commodityCount[STUFF_STEEL] -= INDUSTRY_L_STEEL_USED;
+            consumeStuff(STUFF_JOBS, INDUSTRY_L_JOBS_LOAD_STEEL + JOBS_LOAD_STEEL);
+            consumeStuff(STUFF_STEEL, INDUSTRY_L_STEEL_USED);
             goods_today *= 2;
         }
         //now check for more ore and power to quadruple goods_today again
@@ -71,37 +80,30 @@ void IndustryLight::update()
          && (commodityCount[STUFF_GOODS] + 4 * goods_today <= MAX_GOODS_AT_INDUSTRY_L))
         {
             goods_today *= 4;
-            commodityCount[STUFF_ORE] -= INDUSTRY_L_ORE_USED;
+            consumeStuff(STUFF_ORE, INDUSTRY_L_ORE_USED);
             //prefer the mor abundant power
             if(2 * commodityCount[STUFF_MWH] > commodityCount[STUFF_KWH])
             {
-                commodityCount[STUFF_MWH] -= INDUSTRY_L_POWER_PER_GOOD * (goods_today / 2);
+                consumeStuff(STUFF_MWH, INDUSTRY_L_POWER_PER_GOOD * (goods_today / 2));
                 if(commodityCount[STUFF_MWH] < 0)
                 {
-                commodityCount[STUFF_KWH] += 2 * commodityCount[STUFF_MWH];
-                commodityCount[STUFF_MWH] = 0;
+                    int deficit = levelStuff(STUFF_MWH, 0);
+                    consumeStuff(STUFF_KWH, deficit * 2);
                 }
             }
             else
             {
-                commodityCount[STUFF_KWH] -= INDUSTRY_L_POWER_PER_GOOD * goods_today;
+                consumeStuff(STUFF_KWH, INDUSTRY_L_POWER_PER_GOOD * goods_today);
                 if(commodityCount[STUFF_KWH] < 0)
                 {
-                commodityCount[STUFF_MWH] += commodityCount[STUFF_KWH]/2;
-                commodityCount[STUFF_KWH] = 0;
+                    int deficit = levelStuff(STUFF_KWH, 0);
+                    consumeStuff(STUFF_MWH, deficit / 2);
                 }
             }
         }
-        commodityCount[STUFF_GOODS] += goods_today;
+        produceStuff(STUFF_GOODS, goods_today);
         goods_this_month += goods_today;
     }// endif make some goods
-    //monthly update
-    if (total_time % 100 == 0)
-    {
-        int output_level = goods_this_month / (INDUSTRY_L_MAKE_GOODS * 8);
-        busy = output_level;
-        goods_this_month = 0;
-    }// end monthly update
 }
 
 void IndustryLight::animate() {

--- a/src/lincity/modules/light_industry.h
+++ b/src/lincity/modules/light_industry.h
@@ -127,6 +127,20 @@ public:
                 extra_bonus /= MAX_TECH_LEVEL;
             }
         }
+
+        commodityMaxCons[STUFF_JOBS] = 100 * (INDUSTRY_L_JOBS_USED +
+          INDUSTRY_L_JOBS_LOAD_ORE + JOBS_LOAD_ORE +
+          INDUSTRY_L_JOBS_LOAD_STEEL + JOBS_LOAD_STEEL);
+        commodityMaxCons[STUFF_ORE] = 100 * INDUSTRY_L_ORE_USED * 2;
+        commodityMaxCons[STUFF_STEEL] = 100 * INDUSTRY_L_STEEL_USED;
+        commodityMaxCons[STUFF_KWH] = 100 *
+          INDUSTRY_L_POWER_PER_GOOD * INDUSTRY_L_MAKE_GOODS * 8;
+        commodityMaxCons[STUFF_MWH] = 100 *
+          INDUSTRY_L_POWER_PER_GOOD * INDUSTRY_L_MAKE_GOODS * 4;
+        commodityMaxProd[STUFF_GOODS] = 100 * INDUSTRY_L_MAKE_GOODS * 8;
+        commodityMaxProd[STUFF_WASTE] = 100 * (int)(INDUSTRY_L_POL_PER_GOOD *
+          INDUSTRY_L_MAKE_GOODS * bonus * (1-extra_bonus));
+        // TODO: update this after loading saved members
     }
 
     virtual ~IndustryLight() //remove 2 or more extraframes

--- a/src/lincity/modules/light_industry.h
+++ b/src/lincity/modules/light_industry.h
@@ -109,9 +109,42 @@ public:
         this->anim = 0;
         initialize_commodities();
         this->bonus = 0;
-        setMemberSaved(&this->bonus, "bonus");
+        setMemberSaved(&this->bonus, "bonus"); // compatibility
         this->extra_bonus = 0;
-        setMemberSaved(&this->extra_bonus, "extra_bonus");
+        setMemberSaved(&this->extra_bonus, "extra_bonus"); // compatibility
+        // if (tech > MAX_TECH_LEVEL)
+        // {
+        //     bonus = (tech - MAX_TECH_LEVEL);
+        //     if (bonus > MAX_TECH_LEVEL)
+        //         bonus = MAX_TECH_LEVEL;
+        //     bonus /= MAX_TECH_LEVEL;
+        //     // check for filter technology bonus
+        //     if (tech > 2 * MAX_TECH_LEVEL)
+        //     {
+        //         extra_bonus = tech - 2 * MAX_TECH_LEVEL;
+        //         if (extra_bonus > MAX_TECH_LEVEL)
+        //             extra_bonus = MAX_TECH_LEVEL;
+        //         extra_bonus /= MAX_TECH_LEVEL;
+        //     }
+        // }
+
+        commodityMaxCons[STUFF_JOBS] = 100 * (INDUSTRY_L_JOBS_USED +
+          INDUSTRY_L_JOBS_LOAD_ORE + JOBS_LOAD_ORE +
+          INDUSTRY_L_JOBS_LOAD_STEEL + JOBS_LOAD_STEEL);
+        commodityMaxCons[STUFF_ORE] = 100 * INDUSTRY_L_ORE_USED * 2;
+        commodityMaxCons[STUFF_STEEL] = 100 * INDUSTRY_L_STEEL_USED;
+        commodityMaxCons[STUFF_KWH] = 100 *
+          INDUSTRY_L_POWER_PER_GOOD * INDUSTRY_L_MAKE_GOODS * 8;
+        commodityMaxCons[STUFF_MWH] = 100 *
+          INDUSTRY_L_POWER_PER_GOOD * INDUSTRY_L_MAKE_GOODS * 4;
+        commodityMaxProd[STUFF_GOODS] = 100 * INDUSTRY_L_MAKE_GOODS * 8;
+        // commodityMaxProd[STUFF_WASTE] = 100 * (int)(INDUSTRY_L_POL_PER_GOOD *
+        //   INDUSTRY_L_MAKE_GOODS * bonus * (1-extra_bonus));
+    }
+
+    virtual void initialize() override {
+        RegisteredConstruction::initialize();
+
         if (tech > MAX_TECH_LEVEL)
         {
             bonus = (tech - MAX_TECH_LEVEL);
@@ -128,19 +161,8 @@ public:
             }
         }
 
-        commodityMaxCons[STUFF_JOBS] = 100 * (INDUSTRY_L_JOBS_USED +
-          INDUSTRY_L_JOBS_LOAD_ORE + JOBS_LOAD_ORE +
-          INDUSTRY_L_JOBS_LOAD_STEEL + JOBS_LOAD_STEEL);
-        commodityMaxCons[STUFF_ORE] = 100 * INDUSTRY_L_ORE_USED * 2;
-        commodityMaxCons[STUFF_STEEL] = 100 * INDUSTRY_L_STEEL_USED;
-        commodityMaxCons[STUFF_KWH] = 100 *
-          INDUSTRY_L_POWER_PER_GOOD * INDUSTRY_L_MAKE_GOODS * 8;
-        commodityMaxCons[STUFF_MWH] = 100 *
-          INDUSTRY_L_POWER_PER_GOOD * INDUSTRY_L_MAKE_GOODS * 4;
-        commodityMaxProd[STUFF_GOODS] = 100 * INDUSTRY_L_MAKE_GOODS * 8;
         commodityMaxProd[STUFF_WASTE] = 100 * (int)(INDUSTRY_L_POL_PER_GOOD *
           INDUSTRY_L_MAKE_GOODS * bonus * (1-extra_bonus));
-        // TODO: update this after loading saved members
     }
 
     virtual ~IndustryLight() //remove 2 or more extraframes
@@ -155,6 +177,7 @@ public:
             }
         }
     }
+
     virtual void update() override;
     virtual void report() override;
     virtual void animate() override;

--- a/src/lincity/modules/light_industry.h
+++ b/src/lincity/modules/light_industry.h
@@ -37,7 +37,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_INDUSTRY_L;

--- a/src/lincity/modules/market.cpp
+++ b/src/lincity/modules/market.cpp
@@ -100,14 +100,22 @@ void Market::update()
 
     if (commodityCount[STUFF_JOBS] >= jobs)
     {
-        commodityCount[STUFF_JOBS] -= jobs;
+        consumeStuff(STUFF_JOBS, jobs);
         //Have to collect taxes here since transport does not consider the market a consumer but rather as another transport
         income_tax += jobs;
         ++working_days;
     }
+
+    if(total_time % 50)
+    if(commodityCount[STUFF_WASTE] >= 85 * MAX_WASTE_IN_MARKET / 100) {
+        start_burning_waste = true;
+        world(x+1,y+1)->pollution += MAX_WASTE_IN_MARKET/20;
+        consumeStuff(STUFF_WASTE, (7 * MAX_WASTE_IN_MARKET) / 10);
+    }
+
     //monthly update
-    if (total_time % 100 == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }
@@ -136,13 +144,6 @@ void Market::update()
         {
             jobs = JOBS_MARKET_FULL;
         }
-    }
-
-    if(total_time % 50)
-    if(commodityCount[STUFF_WASTE] >= 85 * MAX_WASTE_IN_MARKET / 100) {
-        start_burning_waste = true;
-        world(x+1,y+1)->pollution += MAX_WASTE_IN_MARKET/20;
-        commodityCount[STUFF_WASTE] -= (7 * MAX_WASTE_IN_MARKET) / 10;
     }
 
     if(refresh_cover)

--- a/src/lincity/modules/market.h
+++ b/src/lincity/modules/market.h
@@ -101,6 +101,9 @@ public:
         tmp = y + constructionGroup->range + constructionGroup->size;
         this->ye = (tmp > lenm1)? lenm1 : tmp;
         this->cover();
+
+        commodityMaxCons[STUFF_JOBS] = 100 * JOBS_MARKET_FULL;
+        commodityMaxCons[STUFF_WASTE] = 100 * ((7 * MAX_WASTE_IN_MARKET) / 10);
     }
     virtual void update() override;
     virtual void report() override;

--- a/src/lincity/modules/market.h
+++ b/src/lincity/modules/market.h
@@ -36,7 +36,8 @@ public:
         int cost_mul, int bul_cost, int market_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, market_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, market_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_FOOD].maxload = MAX_FOOD_IN_MARKET;
         commodityRuleCount[STUFF_FOOD].take = true;

--- a/src/lincity/modules/mill.cpp
+++ b/src/lincity/modules/mill.cpp
@@ -74,7 +74,7 @@ void Mill::report()
     int i = 0;
     mps_store_sd(i++, constructionGroup->name, ID);
     mps_store_sfp(i++, N_("busy"), (float) busy);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/mill.cpp
+++ b/src/lincity/modules/mill.cpp
@@ -35,10 +35,13 @@ void Mill::update()
     && (commodityCount[STUFF_JOBS] >= MILL_JOBS)
     && (commodityCount[STUFF_GOODS] <= MAX_GOODS_AT_MILL - GOODS_MADE_BY_MILL))
     {
-        (use_coal?commodityCount[STUFF_COAL]:commodityCount[STUFF_KWH]) -= (use_coal?COAL_USED_BY_MILL:COAL_USED_BY_MILL * MILL_POWER_PER_COAL);
-        commodityCount[STUFF_FOOD] -= FOOD_USED_BY_MILL;
-        commodityCount[STUFF_JOBS] -= MILL_JOBS;
-        commodityCount[STUFF_GOODS] += GOODS_MADE_BY_MILL;
+        if(use_coal)
+            consumeStuff(STUFF_COAL, COAL_USED_BY_MILL);
+        else
+            consumeStuff(STUFF_KWH, COAL_USED_BY_MILL * MILL_POWER_PER_COAL);
+        consumeStuff(STUFF_FOOD, FOOD_USED_BY_MILL);
+        consumeStuff(STUFF_JOBS, MILL_JOBS);
+        produceStuff(STUFF_GOODS, GOODS_MADE_BY_MILL);
         ++working_days;
         animate_enable = true;
         if ((++pol_count %= 7) == 0)
@@ -46,8 +49,8 @@ void Mill::update()
     }
 
     //monthly update
-    if (total_time % 100 == 0)
-    {
+    if(total_time % 100 == 99) {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/mill.h
+++ b/src/lincity/modules/mill.h
@@ -73,6 +73,13 @@ public:
         this->animate_enable = false;
         this->pol_count = 0;
         initialize_commodities();
+
+        commodityMaxCons[STUFF_COAL] = 100 * COAL_USED_BY_MILL;
+        commodityMaxCons[STUFF_KWH] = 100 *
+          COAL_USED_BY_MILL * MILL_POWER_PER_COAL;
+        commodityMaxCons[STUFF_FOOD] = 100 * FOOD_USED_BY_MILL;
+        commodityMaxCons[STUFF_JOBS] = 100 * MILL_JOBS;
+        commodityMaxCons[STUFF_GOODS] = 100 * GOODS_MADE_BY_MILL;
     }
     virtual ~Mill() { }
     virtual void update() override;

--- a/src/lincity/modules/mill.h
+++ b/src/lincity/modules/mill.h
@@ -35,7 +35,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_MILL;

--- a/src/lincity/modules/monument.cpp
+++ b/src/lincity/modules/monument.cpp
@@ -34,21 +34,12 @@ void Monument::update()
 {
     if ((commodityCount[STUFF_JOBS] > MONUMENT_GET_JOBS) && (completion < 100))
     {
-        commodityCount[STUFF_JOBS] -= MONUMENT_GET_JOBS;
+        consumeStuff(STUFF_JOBS, MONUMENT_GET_JOBS);
         jobs_consumed += MONUMENT_GET_JOBS;
         completion = jobs_consumed * 100 / BUILD_MONUMENT_JOBS;
         ++working_days;
     }
-    //monthly update
-    if (total_time % 100 == 0)
-    {
-        busy = working_days;
-        working_days = 0;
-        if(commodityCount[STUFF_JOBS]==0 && completed)
-        {   deneighborize();}
-    }
-    /* now choose a graphic */
-    if (completion >= 100)
+    else if (completion >= 100)
     {
         if(!completed)
         {
@@ -71,6 +62,15 @@ void Monument::update()
                 tail_off = 0;
             }
         }
+    }
+    //monthly update
+    if (total_time % 100 == 99)
+    {
+        reset_prod_counters();
+        busy = working_days;
+        working_days = 0;
+        if(commodityCount[STUFF_JOBS]==0 && completed)
+        {   deneighborize();}
     }
 }
 

--- a/src/lincity/modules/monument.cpp
+++ b/src/lincity/modules/monument.cpp
@@ -99,7 +99,7 @@ void Monument::report()
     else
     {
         mps_store_sfp(i++, N_("busy"), (float) busy);
-        i++;
+        // i++;
         list_commodities(&i);
         i++;
         mps_store_sfp(i++, N_("Completion"), completion);

--- a/src/lincity/modules/monument.h
+++ b/src/lincity/modules/monument.h
@@ -62,6 +62,7 @@ public:
         setMemberSaved(&this->jobs_consumed, "jobs_consumed");
         initialize_commodities();
 
+        commodityMaxCons[STUFF_JOBS] = 100 * MONUMENT_GET_JOBS;
     }
 
     virtual ~Monument() { }

--- a/src/lincity/modules/monument.h
+++ b/src/lincity/modules/monument.h
@@ -28,7 +28,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_MONUMENT;
         commodityRuleCount[STUFF_JOBS].take = true;

--- a/src/lincity/modules/oremine.cpp
+++ b/src/lincity/modules/oremine.cpp
@@ -49,8 +49,8 @@ void Oremine::update()
                     world(xx,yy)->ore_reserve--;
                     world(xx,yy)->flags |= FLAG_ALTERED;
                     total_ore_reserve--;
-                    commodityCount[STUFF_ORE] += ORE_PER_RESERVE;
-                    commodityCount[STUFF_JOBS] -= OREMINE_JOBS;
+                    produceStuff(STUFF_ORE, ORE_PER_RESERVE);
+                    consumeStuff(STUFF_JOBS, OREMINE_JOBS);
                     //FIXME ore_tax should be handled upon delivery
                     //ore_made += ORE_PER_RESERVE;
                     if (total_ore_reserve < (constructionGroup->size * constructionGroup->size * ORE_RESERVE))
@@ -75,8 +75,8 @@ void Oremine::update()
                     world(xx,yy)->ore_reserve++;
                     world(xx,yy)->flags |= FLAG_ALTERED;
                     total_ore_reserve++;
-                    commodityCount[STUFF_ORE] -= ORE_PER_RESERVE;
-                    commodityCount[STUFF_JOBS] -= OREMINE_JOBS;
+                    consumeStuff(STUFF_ORE, ORE_PER_RESERVE);
+                    consumeStuff(STUFF_JOBS, OREMINE_JOBS);
                     animate_enable = true;
                     working_days++;
                     goto end_mining;
@@ -87,8 +87,8 @@ void Oremine::update()
     end_mining:
 
     //Monthly update of activity
-    if (total_time % 100 == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/oremine.cpp
+++ b/src/lincity/modules/oremine.cpp
@@ -127,7 +127,7 @@ void Oremine::report()
     mps_store_sd(i++, constructionGroup->name, ID);
     mps_store_sfp(i++, N_("busy"), busy);
     mps_store_sddp(i++, N_("Deposits"), total_ore_reserve, (constructionGroup->size * constructionGroup->size * ORE_RESERVE));
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/oremine.h
+++ b/src/lincity/modules/oremine.h
@@ -73,6 +73,10 @@ public:
         { ore = 1;}
         this->total_ore_reserve = ore;
         setMemberSaved(&this->total_ore_reserve, "total_ore_reserve");
+
+        commodityMaxProd[STUFF_ORE] = 100 * ORE_PER_RESERVE;
+        commodityMaxCons[STUFF_ORE] = 100 * ORE_PER_RESERVE;
+        commodityMaxCons[STUFF_JOBS] = 100 * OREMINE_JOBS;
     }
     virtual ~Oremine() {}
     virtual void update() override;

--- a/src/lincity/modules/oremine.h
+++ b/src/lincity/modules/oremine.h
@@ -32,7 +32,8 @@ public:
         unsigned short size, int colour,
         int cost_mul, int bul_cost, int fire_chance, int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_OREMINE;
         commodityRuleCount[STUFF_JOBS].take = true;

--- a/src/lincity/modules/organic_farm.cpp
+++ b/src/lincity/modules/organic_farm.cpp
@@ -114,7 +114,7 @@ void Organic_farm::report()
     mps_store_sfp(i++, N_("Tech"), tech * 100.0 / MAX_TECH_LEVEL);
     mps_store_sfp(i++, N_("busy"), (float)food_last_month / 100.0);
     mps_store_sd(i++, N_("Output"), max_foodprod);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/organic_farm.cpp
+++ b/src/lincity/modules/organic_farm.cpp
@@ -44,7 +44,7 @@ void Organic_farm::update()
         used_power = ORG_FARM_POWER_REC;
         flags |= FLAG_POWERED;
         if (commodityCount[STUFF_WASTE] >= 3 * ORG_FARM_WASTE_GET)
-        {   commodityCount[STUFF_WASTE] -= ORG_FARM_WASTE_GET;}
+        {   consumeStuff(STUFF_WASTE, ORG_FARM_WASTE_GET);}
         used_water = commodityCount[STUFF_WATER] / WATER_FARM;
         if (used_water > (16 - ugwCount))
         {   used_water = (16 - ugwCount);}
@@ -73,15 +73,15 @@ void Organic_farm::update()
     /* Now apply changes */
     if (foodprod >= 30)
     {
-        commodityCount[STUFF_JOBS] -= used_jobs;
-        commodityCount[STUFF_FOOD] += foodprod;
-        commodityCount[STUFF_KWH] -= used_power;
-        commodityCount[STUFF_WATER] -= (used_water * WATER_FARM);
+        consumeStuff(STUFF_JOBS, used_jobs);
+        produceStuff(STUFF_FOOD, foodprod);
+        consumeStuff(STUFF_KWH, used_power);
+        consumeStuff(STUFF_WATER, used_water * WATER_FARM);
         food_this_month += 100 * foodprod / max_foodprod;
     }
     // monthly update
-    if ((total_time % 100) == 0)
-    {
+    if (total_time % 100 == 99) {
+        reset_prod_counters();
         food_last_month = food_this_month;
         food_this_month = 0;
     }

--- a/src/lincity/modules/organic_farm.h
+++ b/src/lincity/modules/organic_farm.h
@@ -44,7 +44,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_FOOD].maxload = MAX_ORG_FARM_FOOD;

--- a/src/lincity/modules/organic_farm.h
+++ b/src/lincity/modules/organic_farm.h
@@ -104,6 +104,10 @@ public:
         {
             this->ugwCount = 16;
         }
+
+        commodityMaxCons[STUFF_WASTE] = 100 * ORG_FARM_WASTE_GET;
+        commodityMaxCons[STUFF_JOBS] = 100 * FARM_JOBS_USED;
+        commodityMaxProd[STUFF_FOOD] = 100 * (ORGANIC_FARM_FOOD_OUTPUT + tech_bonus)
     }
     virtual ~Organic_farm() { }
     virtual void update() override;

--- a/src/lincity/modules/organic_farm.h
+++ b/src/lincity/modules/organic_farm.h
@@ -78,8 +78,8 @@ public:
         init_resources();
         this->tech = tech_level;
         setMemberSaved(&this->tech, "tech");
-        this->tech_bonus = int( ((long long int)tech_level * ORGANIC_FARM_FOOD_OUTPUT) / MAX_TECH_LEVEL );
-        setMemberSaved(&this->tech_bonus, "tech_bonus");
+        // this->tech_bonus = int( ((long long int)tech_level * ORGANIC_FARM_FOOD_OUTPUT) / MAX_TECH_LEVEL );
+        setMemberSaved(&this->tech_bonus, "tech_bonus"); // compatibility
         this->crop_rotation_key = (rand() % 4) + 1;
         this->month_stagger = rand() % 100;
         this->food_this_month = 0;
@@ -109,9 +109,19 @@ public:
         commodityMaxCons[STUFF_JOBS] = 100 * FARM_JOBS_USED;
         commodityMaxCons[STUFF_KWH] = 100 * ORG_FARM_POWER_REC;
         commodityMaxCons[STUFF_WATER] = 100 * 16 * WATER_FARM;
+        // commodityMaxProd[STUFF_FOOD] = 100 *
+        //   (ORGANIC_FARM_FOOD_OUTPUT + tech_bonus);
+    }
+
+    virtual void initialize() override {
+        RegisteredConstruction::initialize();
+
+        this->tech_bonus = int( ((long long int)tech_level * ORGANIC_FARM_FOOD_OUTPUT) / MAX_TECH_LEVEL );
+
         commodityMaxProd[STUFF_FOOD] = 100 *
           (ORGANIC_FARM_FOOD_OUTPUT + tech_bonus);
     }
+
     virtual ~Organic_farm() { }
     virtual void update() override;
     virtual void report() override;

--- a/src/lincity/modules/organic_farm.h
+++ b/src/lincity/modules/organic_farm.h
@@ -107,7 +107,10 @@ public:
 
         commodityMaxCons[STUFF_WASTE] = 100 * ORG_FARM_WASTE_GET;
         commodityMaxCons[STUFF_JOBS] = 100 * FARM_JOBS_USED;
-        commodityMaxProd[STUFF_FOOD] = 100 * (ORGANIC_FARM_FOOD_OUTPUT + tech_bonus)
+        commodityMaxCons[STUFF_KWH] = 100 * ORG_FARM_POWER_REC;
+        commodityMaxCons[STUFF_WATER] = 100 * 16 * WATER_FARM;
+        commodityMaxProd[STUFF_FOOD] = 100 *
+          (ORGANIC_FARM_FOOD_OUTPUT + tech_bonus);
     }
     virtual ~Organic_farm() { }
     virtual void update() override;

--- a/src/lincity/modules/parkland.h
+++ b/src/lincity/modules/parkland.h
@@ -22,7 +22,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 1/*mps_pages*/
     ) {
 
     };
@@ -46,4 +47,3 @@ public:
 };
 
 /** @file lincity/modules/parkland.h */
-

--- a/src/lincity/modules/port.cpp
+++ b/src/lincity/modules/port.cpp
@@ -117,7 +117,7 @@ void Port::report()
     mps_store_sd(i++, N_("Export"),lastm_et/100);
     mps_store_sd(i++, N_("Import"),lastm_ic/100);
     mps_store_sfp(i++, N_("Culture exchanged"), tech_made * 100.0 / MAX_TECH_LEVEL);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/port.cpp
+++ b/src/lincity/modules/port.cpp
@@ -36,7 +36,7 @@ int Port::buy_stuff(Commodity stuff)
     i = (i * PORT_IMPORT_RATE) / 1000;
     if (i < (portConstructionGroup.commodityRuleCount[stuff].maxload / PORT_TRIGGER_RATE))
     {   return 0;}
-    commodityCount[stuff] += i;
+    produceStuff(stuff, i);
     return (i * portConstructionGroup.commodityRates[stuff]);
 }
 
@@ -48,7 +48,7 @@ int Port::sell_stuff(Commodity stuff)
     i = (i * PORT_EXPORT_RATE) / 1000;
     if (i < (portConstructionGroup.commodityRuleCount[stuff].maxload / PORT_TRIGGER_RATE))
     {   return 0;}
-    commodityCount[stuff] -= i;
+    consumeStuff(stuff, i);
     return (i * portConstructionGroup.commodityRates[stuff]);
 }
 
@@ -79,7 +79,7 @@ void Port::update()
         trade_connection();
         if (daily_ic || daily_et)
         {
-            commodityCount[STUFF_JOBS] -= PORT_JOBS;
+            consumeStuff(STUFF_JOBS, PORT_JOBS);
             world(x,y)->pollution += PORT_POLLUTION;
             sust_port_flag = 0;
             tech_made++;
@@ -92,8 +92,9 @@ void Port::update()
     monthly_ic += daily_ic;
     monthly_et += daily_et;
     //monthly update
-    if (total_time % 100 == 0)
+    if (total_time % 100 == 99)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
         lastm_ic = monthly_ic;

--- a/src/lincity/modules/port.h
+++ b/src/lincity/modules/port.h
@@ -53,7 +53,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_ON_PORT;
         commodityRuleCount[STUFF_JOBS].take = true;

--- a/src/lincity/modules/port.h
+++ b/src/lincity/modules/port.h
@@ -126,15 +126,15 @@ public:
         commodityRuleCount[STUFF_STEEL].give = false;
         setCommodityRulesSaved(&commodityRuleCount);
 
-        commodityMaxCons[STUFF_JOBS] = PORT_JOBS;
+        commodityMaxCons[STUFF_JOBS] = 100 * PORT_JOBS;
         for(Commodity stuff = STUFF_INIT ; stuff < STUFF_COUNT ; stuff++) {
             if(!commodityRuleCount[stuff].maxload) continue;
             commodityMaxCons[stuff] = 100 * ((
               portConstructionGroup.commodityRuleCount[stuff].maxload *
-              PORT_EXPORT_RATE) / 1000)
+              PORT_EXPORT_RATE) / 1000);
             commodityMaxProd[stuff] = 100 * ((
               portConstructionGroup.commodityRuleCount[stuff].maxload *
-              PORT_IMPORT_RATE) / 1000)
+              PORT_IMPORT_RATE) / 1000);
         }
     }
     virtual ~Port() { }

--- a/src/lincity/modules/port.h
+++ b/src/lincity/modules/port.h
@@ -125,6 +125,17 @@ public:
         commodityRuleCount[STUFF_STEEL].take = false;
         commodityRuleCount[STUFF_STEEL].give = false;
         setCommodityRulesSaved(&commodityRuleCount);
+
+        commodityMaxCons[STUFF_JOBS] = PORT_JOBS;
+        for(Commodity stuff = STUFF_INIT ; stuff < STUFF_COUNT ; stuff++) {
+            if(!commodityRuleCount[stuff].maxload) continue;
+            commodityMaxCons[stuff] = 100 * ((
+              portConstructionGroup.commodityRuleCount[stuff].maxload *
+              PORT_EXPORT_RATE) / 1000)
+            commodityMaxProd[stuff] = 100 * ((
+              portConstructionGroup.commodityRuleCount[stuff].maxload *
+              PORT_IMPORT_RATE) / 1000)
+        }
     }
     virtual ~Port() { }
     virtual void update();

--- a/src/lincity/modules/pottery.cpp
+++ b/src/lincity/modules/pottery.cpp
@@ -29,6 +29,7 @@ void Pottery::update()
 {
     if (total_time % 100 == 0)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/pottery.cpp
+++ b/src/lincity/modules/pottery.cpp
@@ -80,7 +80,7 @@ void Pottery::report()
     mps_store_sd(i++, constructionGroup->name, ID);
     i++;
     mps_store_sfp(i++, N_("busy"), (float) busy);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/pottery.cpp
+++ b/src/lincity/modules/pottery.cpp
@@ -41,10 +41,10 @@ void Pottery::update()
      && (commodityCount[STUFF_COAL] >= POTTERY_COAL_MAKE_GOODS)
      && (commodityCount[STUFF_JOBS] >= POTTERY_JOBS))
     {
-        commodityCount[STUFF_GOODS] += POTTERY_MADE_GOODS;
-        commodityCount[STUFF_ORE] -= POTTERY_ORE_MAKE_GOODS;
-        commodityCount[STUFF_COAL] -= POTTERY_COAL_MAKE_GOODS;
-        commodityCount[STUFF_JOBS] -= POTTERY_JOBS;
+        produceStuff(STUFF_GOODS, POTTERY_MADE_GOODS);
+        consumeStuff(STUFF_ORE, POTTERY_ORE_MAKE_GOODS);
+        consumeStuff(STUFF_COAL, POTTERY_COAL_MAKE_GOODS);
+        consumeStuff(STUFF_JOBS, POTTERY_JOBS);
 
         animate_enable = true;
         if(!((working_days++)%10))

--- a/src/lincity/modules/pottery.h
+++ b/src/lincity/modules/pottery.h
@@ -66,6 +66,11 @@ public:
         this->working_days = 0;
         this->animate_enable = false;
         initialize_commodities();
+
+        commodityMaxProd[STUFF_GOODS] = 100 * POTTERY_MADE_GOODS;
+        commodityMaxCons[STUFF_ORE] = 100 * POTTERY_ORE_MAKE_GOODS;
+        commodityMaxCons[STUFF_COAL] = 100 * POTTERY_COAL_MAKE_GOODS;
+        commodityMaxCons[STUFF_JOBS] = 100 * POTTERY_JOBS;
     }
     virtual ~Pottery() { }
     virtual void update() override;

--- a/src/lincity/modules/pottery.h
+++ b/src/lincity/modules/pottery.h
@@ -31,7 +31,8 @@ public:
         unsigned short size, int colour,
         int cost_mul, int bul_cost, int fire_chance, int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_POTTERY;

--- a/src/lincity/modules/power_line.cpp
+++ b/src/lincity/modules/power_line.cpp
@@ -66,7 +66,7 @@ void Powerline::report()
 
     mps_store_sd(i++, constructionGroup->name, ID);
     mps_store_sfp(i++, N_("usage"), trafficCount[STUFF_MWH] * 107.77 * TRANSPORT_RATE / TRANSPORT_QUANTA);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/power_line.cpp
+++ b/src/lincity/modules/power_line.cpp
@@ -31,8 +31,12 @@ void Powerline::update()
 {
     if (commodityCount[STUFF_MWH] > 0)
     {
-        commodityCount[STUFF_MWH]--;// loss on powerline
+        consumeStuff(STUFF_MWH, 1);// loss on powerline
     } // endif MWH
+
+    if(total_time % 100 == 99) {
+        reset_prod_counters();
+    }
 }
 
 void Powerline::animate() {

--- a/src/lincity/modules/power_line.h
+++ b/src/lincity/modules/power_line.h
@@ -15,7 +15,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_MWH].maxload = MAX_MWH_ON_POWERLINE;

--- a/src/lincity/modules/power_line.h
+++ b/src/lincity/modules/power_line.h
@@ -41,6 +41,8 @@ public:
         this->flashing = false;
         initialize_commodities();
         this->trafficCount = this->commodityCount;
+
+        commodityMaxCons[STUFF_MWH] = 100 * 1
     }
     virtual ~Powerline() { }
     virtual void update() override;

--- a/src/lincity/modules/power_line.h
+++ b/src/lincity/modules/power_line.h
@@ -42,7 +42,7 @@ public:
         initialize_commodities();
         this->trafficCount = this->commodityCount;
 
-        commodityMaxCons[STUFF_MWH] = 100 * 1
+        commodityMaxCons[STUFF_MWH] = 100 * 1;
     }
     virtual ~Powerline() { }
     virtual void update() override;

--- a/src/lincity/modules/recycle.cpp
+++ b/src/lincity/modules/recycle.cpp
@@ -70,7 +70,7 @@ void Recycle::report()
     mps_store_sfp(i++, N_("Efficiency Ore"), (float) make_ore * 100 / WASTE_RECYCLED);
     mps_store_sfp(i++, N_("Efficiency Steel"),(float) make_steel * 100 / WASTE_RECYCLED);
     mps_store_sfp(i++, N_("busy"), busy);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/recycle.cpp
+++ b/src/lincity/modules/recycle.cpp
@@ -35,28 +35,29 @@ void Recycle::update()
         && commodityCount[STUFF_KWH] >= KWH_RECYCLE_WASTE
         && commodityCount[STUFF_JOBS] >= RECYCLE_JOBS)
     {
-        commodityCount[STUFF_JOBS] -= RECYCLE_JOBS;
-        commodityCount[STUFF_KWH] -= KWH_RECYCLE_WASTE;
-        commodityCount[STUFF_WASTE] -= WASTE_RECYCLED;
+        consumeStuff(STUFF_JOBS, RECYCLE_JOBS);
+        consumeStuff(STUFF_KWH, KWH_RECYCLE_WASTE);
+        consumeStuff(STUFF_WASTE, WASTE_RECYCLED);
         working_days++;
         // rather loose ore / steel than stop recycling the waste
-        commodityCount[STUFF_ORE] += make_ore;
-        commodityCount[STUFF_STEEL] += make_steel;
+        produceStuff(STUFF_ORE, make_ore);
+        produceStuff(STUFF_STEEL, make_steel);
         if(commodityCount[STUFF_ORE]>MAX_ORE_AT_RECYCLE)
-        {   commodityCount[STUFF_ORE]=MAX_ORE_AT_RECYCLE;}
+        {   levelStuff(STUFF_ORE, MAX_ORE_AT_RECYCLE);}
         if(commodityCount[STUFF_STEEL]>MAX_STEEL_AT_RECYCLE)
-        {   commodityCount[STUFF_STEEL]=MAX_STEEL_AT_RECYCLE;}
+        {   levelStuff(STUFF_STEEL, MAX_STEEL_AT_RECYCLE);}
 
     }
     // monthly update
-    if (total_time % 100 == 0)
+    if (total_time % 100 == 99)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }
     // if we've still >90% waste in stock, burn some waste cleanly.
     if (commodityCount[STUFF_WASTE] > (MAX_WASTE_AT_RECYCLE * 9 / 10))
-    {   commodityCount[STUFF_WASTE] -= BURN_WASTE_AT_RECYCLE;}
+    {   consumeStuff(STUFF_WASTE, BURN_WASTE_AT_RECYCLE);}
 }
 
 void Recycle::report()
@@ -74,4 +75,3 @@ void Recycle::report()
 }
 
 /** @file lincity/modules/recycle.cpp */
-

--- a/src/lincity/modules/recycle.h
+++ b/src/lincity/modules/recycle.h
@@ -73,22 +73,38 @@ public:
         this->tech = tech_level;
         setMemberSaved(&this->tech, "tech");
         initialize_commodities();
-        int efficiency;
-        efficiency = ( WASTE_RECYCLED * (10 + ( (50 * tech) / MAX_TECH_LEVEL)) ) / 100;
-        if (efficiency > (WASTE_RECYCLED * 8) / 10)
-        {   efficiency = (WASTE_RECYCLED * 8) / 10;}
-        this->make_ore = efficiency;
-        setMemberSaved(&this->make_ore, "make_ore");
-        this->make_steel = efficiency / 50;
-        setMemberSaved(&this->make_steel, "make_steel");
+        // int efficiency;
+        // efficiency = ( WASTE_RECYCLED * (10 + ( (50 * tech) / MAX_TECH_LEVEL)) ) / 100;
+        // if (efficiency > (WASTE_RECYCLED * 8) / 10)
+        // {   efficiency = (WASTE_RECYCLED * 8) / 10;}
+        // this->make_ore = efficiency;
+        setMemberSaved(&this->make_ore, "make_ore"); // compatibility
+        // this->make_steel = efficiency / 50;
+        setMemberSaved(&this->make_steel, "make_steel"); // compatibility
 
         commodityMaxCons[STUFF_JOBS] = 100 * RECYCLE_JOBS;
         commodityMaxCons[STUFF_KWH] = 100 * KWH_RECYCLE_WASTE;
         commodityMaxCons[STUFF_WASTE] = 100 *
           (WASTE_RECYCLED + BURN_WASTE_AT_RECYCLE);
+        // commodityMaxProd[STUFF_ORE] = 100 * make_ore;
+        // commodityMaxProd[STUFF_STEEL] = 100 * make_steel;
+    }
+
+    virtual void initialize() override {
+        RegisteredConstruction::initialize();
+
+
+        int efficiency =
+          (WASTE_RECYCLED * (10 + ((50 * tech) / MAX_TECH_LEVEL))) / 100;
+        if (efficiency > (WASTE_RECYCLED * 8) / 10)
+        {   efficiency = (WASTE_RECYCLED * 8) / 10;}
+        this->make_ore = efficiency;
+        this->make_steel = efficiency / 50;
+
         commodityMaxProd[STUFF_ORE] = 100 * make_ore;
         commodityMaxProd[STUFF_STEEL] = 100 * make_steel;
     }
+
     virtual ~Recycle() { }
     virtual void update();
     virtual void report();

--- a/src/lincity/modules/recycle.h
+++ b/src/lincity/modules/recycle.h
@@ -36,7 +36,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_RECYCLE;
@@ -92,4 +93,3 @@ public:
 };
 
 /** @file lincity/modules/recycle.h */
-

--- a/src/lincity/modules/recycle.h
+++ b/src/lincity/modules/recycle.h
@@ -81,6 +81,13 @@ public:
         setMemberSaved(&this->make_ore, "make_ore");
         this->make_steel = efficiency / 50;
         setMemberSaved(&this->make_steel, "make_steel");
+
+        commodityMaxCons[STUFF_JOBS] = 100 * RECYCLE_JOBS;
+        commodityMaxCons[STUFF_KWH] = 100 * KWH_RECYCLE_WASTE;
+        commodityMaxCons[STUFF_WASTE] = 100 *
+          (WASTE_RECYCLED + BURN_WASTE_AT_RECYCLE);
+        commodityMaxProd[STUFF_ORE] = 100 * make_ore;
+        commodityMaxProd[STUFF_STEEL] = 100 * make_steel;
     }
     virtual ~Recycle() { }
     virtual void update();

--- a/src/lincity/modules/residence.cpp
+++ b/src/lincity/modules/residence.cpp
@@ -355,7 +355,7 @@ void Residence::report()
     mps_store_sf(i++, N_("Births p.a."), (float)1200/births);
     mps_store_sf(i++, N_("Death p.a."), (float)1200/deaths);
     mps_store_sfp(i++, N_("Unnat. mortality"), (float)pol_deaths);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/residence.cpp
+++ b/src/lincity/modules/residence.cpp
@@ -135,8 +135,8 @@ void Residence::update()
         //&& (world(x,y)->flags & FLAG_WATERWELL_COVER)
         && local_population)
     {
-        commodityCount[STUFF_FOOD] -= local_population;
-        commodityCount[STUFF_WATER] -= local_population;
+        consumeStuff(STUFF_FOOD, local_population);
+        consumeStuff(STUFF_WATER, local_population);
         flags |= (FLAG_FED); //enable births
         good += 10;
     }
@@ -169,7 +169,7 @@ void Residence::update()
      /* now get power for nothing */
     if (commodityCount[STUFF_KWH] >= POWER_RES_OVERHEAD + (POWER_USE_PER_PERSON * local_population))
     {
-        commodityCount[STUFF_KWH] -= POWER_RES_OVERHEAD + (POWER_USE_PER_PERSON * local_population);
+        consumeStuff(STUFF_KWH, POWER_RES_OVERHEAD + (POWER_USE_PER_PERSON * local_population));
         flags |= FLAG_POWERED;
         flags |= FLAG_HAD_POWER;
         good += 10;
@@ -190,7 +190,7 @@ void Residence::update()
 
     if (constructionGroup->commodityRuleCount[STUFF_JOBS].maxload - commodityCount[STUFF_JOBS] >= (local_population * (WORKING_POP_PERCENT + swing) / 100) )
     {
-        commodityCount[STUFF_JOBS] += (local_population * (WORKING_POP_PERCENT + swing) / 100);
+        produceStuff(STUFF_JOBS, local_population * (WORKING_POP_PERCENT + swing) / 100);
         flags |= FLAG_EMPLOYED; //enable births
         if (job_swingometer < -300)
         {   job_swingometer = -300;}
@@ -200,20 +200,20 @@ void Residence::update()
         if ((commodityCount[STUFF_GOODS] >= local_population/4)
         &&  (constructionGroup->commodityRuleCount[STUFF_WASTE].maxload-commodityCount[STUFF_WASTE] >= local_population/12))
         {
-            commodityCount[STUFF_GOODS] -= local_population/4;
-            commodityCount[STUFF_WASTE] += local_population/12;
+            consumeStuff(STUFF_GOODS, local_population/4);
+            produceStuff(STUFF_WASTE, local_population/12);
             good += 10;
             if (commodityCount[STUFF_KWH] >= local_population/2)
             {
-                commodityCount[STUFF_KWH] -= local_population/2;
+                consumeStuff(STUFF_KWH, local_population/2);
                 good += 5;
                 brm += 10;
                 /*     buy more goods if got power for them */
                 if ((commodityCount[STUFF_GOODS] >= local_population/4)
                 &&  (constructionGroup->commodityRuleCount[STUFF_WASTE].maxload-commodityCount[STUFF_WASTE] >= local_population/12))
                 {
-                    commodityCount[STUFF_GOODS] -= local_population/4;
-                    commodityCount[STUFF_WASTE] += local_population/12;
+                    consumeStuff(STUFF_GOODS, local_population/4);
+                    produceStuff(STUFF_WASTE, local_population/12);
                     good += 5;
                 }
             }
@@ -339,6 +339,10 @@ void Residence::update()
     /* XXX AL1: this is daily accumulator used stats.cpp, and maybe pop graph */
    population += local_population;
    housing += max_population;
+
+    if(total_time % 100 == 99) {
+      reset_prod_counters();
+    }
 }
 
 void Residence::report()
@@ -356,4 +360,3 @@ void Residence::report()
 }
 
 /** @file lincity/modules/residence.cpp */
-

--- a/src/lincity/modules/residence.h
+++ b/src/lincity/modules/residence.h
@@ -211,7 +211,7 @@ public:
         commodityMaxProd[STUFF_JOBS] = 100 * (max_population *
           (WORKING_POP_PERCENT + JOB_SWING + HC_JOB_SWING + CRICKET_JOB_SWING)
           / 100);
-        commodityMaxCons[STUFF_GOODS] = 100 * (max_population / 2) * 2;
+        commodityMaxCons[STUFF_GOODS] = 100 * (max_population / 4) * 2;
         commodityMaxProd[STUFF_WASTE] = 100 * (max_population / 12) * 2;
     }
     virtual ~Residence()

--- a/src/lincity/modules/residence.h
+++ b/src/lincity/modules/residence.h
@@ -95,7 +95,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         switch (group)
@@ -219,4 +220,3 @@ public:
 
 
 /** @file lincity/modules/residence.h */
-

--- a/src/lincity/modules/residence.h
+++ b/src/lincity/modules/residence.h
@@ -202,6 +202,16 @@ public:
         }
 
         initialize_commodities();
+
+        commodityMaxCons[STUFF_FOOD] = 100 * max_population;
+        commodityMaxCons[STUFF_WATER] = 100 * max_population;
+        commodityMaxCons[STUFF_KWH] = 100 * (POWER_RES_OVERHEAD +
+          (POWER_USE_PER_PERSON * max_population) + max_population/2);
+        commodityMaxProd[STUFF_JOBS] = 100 * (max_population *
+          (WORKING_POP_PERCENT + JOB_SWING + HC_JOB_SWING + CRICKET_JOB_SWING)
+          / 100)
+        commodityMaxCons[STUFF_GOODS] = 100 * (max_population / 2) * 2
+        commodityMaxProd[STUFF_WASTE] = 100 * (max_population / 12) * 2
     }
     virtual ~Residence()
     {

--- a/src/lincity/modules/residence.h
+++ b/src/lincity/modules/residence.h
@@ -84,6 +84,7 @@
 
 #include "../lintypes.h"
 #include "../lctypes.h"
+#include "cricket.h"
 
 class ResidenceConstructionGroup: public ConstructionGroup {
 public:
@@ -209,9 +210,9 @@ public:
           (POWER_USE_PER_PERSON * max_population) + max_population/2);
         commodityMaxProd[STUFF_JOBS] = 100 * (max_population *
           (WORKING_POP_PERCENT + JOB_SWING + HC_JOB_SWING + CRICKET_JOB_SWING)
-          / 100)
-        commodityMaxCons[STUFF_GOODS] = 100 * (max_population / 2) * 2
-        commodityMaxProd[STUFF_WASTE] = 100 * (max_population / 12) * 2
+          / 100);
+        commodityMaxCons[STUFF_GOODS] = 100 * (max_population / 2) * 2;
+        commodityMaxProd[STUFF_WASTE] = 100 * (max_population / 12) * 2;
     }
     virtual ~Residence()
     {

--- a/src/lincity/modules/rocket_pad.cpp
+++ b/src/lincity/modules/rocket_pad.cpp
@@ -53,13 +53,13 @@ void RocketPad::update()
             && (completion < 100)
          )
     {
-        commodityCount[STUFF_JOBS] -= ROCKET_PAD_JOBS;
+        consumeStuff(STUFF_JOBS, ROCKET_PAD_JOBS);
         jobs_stored += ROCKET_PAD_JOBS;
-        commodityCount[STUFF_GOODS] -= ROCKET_PAD_GOODS;
+        consumeStuff(STUFF_GOODS, ROCKET_PAD_GOODS);
         goods_stored += ROCKET_PAD_GOODS;
-        commodityCount[STUFF_STEEL]-= ROCKET_PAD_STEEL;
+        consumeStuff(STUFF_STEEL, ROCKET_PAD_STEEL);
         steel_stored += ROCKET_PAD_STEEL;
-        commodityCount[STUFF_WASTE] += ROCKET_PAD_GOODS/3;
+        produceStuff(STUFF_WASTE, ROCKET_PAD_GOODS/3);
         step += 2;
         working_days++;
     }
@@ -78,8 +78,9 @@ void RocketPad::update()
         step = 0;
     }
     //monthly update
-    if (total_time % 100 == 0)
+    if (total_time % 100 == 99)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }
@@ -92,7 +93,7 @@ void RocketPad::update()
             anim = real_time + ROCKET_ANIMATION_SPEED;
             frameIt->frame++;
             if(frameIt->frame > last_frame)
-            {   
+            {
                 frameIt->frame = 5;
             } else if (frameIt->frame == last_frame)
             {
@@ -235,4 +236,3 @@ void RocketPad::report()
 }
 
 /** @file lincity/modules/rocket_pad.cpp */
-

--- a/src/lincity/modules/rocket_pad.cpp
+++ b/src/lincity/modules/rocket_pad.cpp
@@ -231,7 +231,7 @@ void RocketPad::report()
     mps_store_sfp(i++, N_("Tech"), (tech * 100.0) / MAX_TECH_LEVEL);
     mps_store_sfp(i++, N_("Overall Progress"), completion);
     mps_store_sfp(i++, N_("Next Step"), step);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/rocket_pad.h
+++ b/src/lincity/modules/rocket_pad.h
@@ -83,6 +83,11 @@ public:
         this->steel_stored = 0;
         setMemberSaved(&this->steel_stored, "steel_stored");
         initialize_commodities();
+
+        commodityMaxCons[STUFF_JOBS] = 100 * ROCKET_PAD_JOBS;
+        commodityMaxCons[STUFF_GOODS] = 100 * ROCKET_PAD_GOODS;
+        commodityMaxCons[STUFF_STEEL] = 100 * ROCKET_PAD_STEEL;
+        commodityMaxProd[STUFF_WASTE] = 100 * (ROCKET_PAD_GOODS/3);
     }
 
     virtual ~RocketPad() { }

--- a/src/lincity/modules/rocket_pad.h
+++ b/src/lincity/modules/rocket_pad.h
@@ -39,7 +39,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_ROCKET_PAD;
         commodityRuleCount[STUFF_JOBS].take = true;
@@ -99,4 +100,3 @@ public:
 
 
 /** @file lincity/modules/rocket_pad.h */
-

--- a/src/lincity/modules/school.cpp
+++ b/src/lincity/modules/school.cpp
@@ -33,15 +33,16 @@ void School::update()
     &&  commodityCount[STUFF_GOODS] >= GOODS_MAKE_TECH_SCHOOL
     &&  commodityCount[STUFF_WASTE] + GOODS_MAKE_TECH_SCHOOL / 3 <= MAX_WASTE_AT_SCHOOL)
     {
-        commodityCount[STUFF_JOBS] -= JOBS_MAKE_TECH_SCHOOL;
-        commodityCount[STUFF_GOODS] -= GOODS_MAKE_TECH_SCHOOL;
-        commodityCount[STUFF_WASTE] += GOODS_MAKE_TECH_SCHOOL / 3;
+        consumeStuff(STUFF_JOBS, JOBS_MAKE_TECH_SCHOOL);
+        consumeStuff(STUFF_GOODS, GOODS_MAKE_TECH_SCHOOL);
+        produceStuff(STUFF_WASTE, GOODS_MAKE_TECH_SCHOOL / 3);
         ++working_days;
         tech_level += TECH_MADE_BY_SCHOOL;
         total_tech_made += TECH_MADE_BY_SCHOOL;
     }
     if ((total_time % 100) == 0)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/school.cpp
+++ b/src/lincity/modules/school.cpp
@@ -83,7 +83,7 @@ void School::report()
     i++;
     mps_store_sfp(i++, N_("busy"), (float)busy);
     mps_store_sfp(i++, N_("Lessons learned"), total_tech_made * 100.0 / MAX_TECH_LEVEL);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/school.h
+++ b/src/lincity/modules/school.h
@@ -34,7 +34,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_SCHOOL;
         commodityRuleCount[STUFF_JOBS].take = true;

--- a/src/lincity/modules/school.h
+++ b/src/lincity/modules/school.h
@@ -74,6 +74,10 @@ public:
         this->total_tech_made = 0;
         setMemberSaved(&this->total_tech_made, "total_tech_made");
         initialize_commodities();
+
+        commodityMaxCons[STUFF_JOBS] = 100 * JOBS_MAKE_TECH_SCHOOL;
+        commodityMaxCons[STUFF_GOODS] = 100 * GOODS_MAKE_TECH_SCHOOL;
+        commodityMaxProd[STUFF_WASTE] = 100 * (GOODS_MAKE_TECH_SCHOOL/3);
     }
 
     virtual ~School() //remove the one extraframe

--- a/src/lincity/modules/shanty.cpp
+++ b/src/lincity/modules/shanty.cpp
@@ -185,7 +185,7 @@ void Shanty::report()
     int i = 0;
     mps_store_sd(i++, constructionGroup->name, ID);
     mps_store_sd(i++, N_("Air Pollution"), world(x,y)->pollution);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/shanty.cpp
+++ b/src/lincity/modules/shanty.cpp
@@ -125,37 +125,38 @@ void update_shanty(void)
 void Shanty::update()
 {
     //steal stuff and make waste
-    commodityCount[STUFF_WASTE] += SHANTY_PUT_WASTE;
+    produceStuff(STUFF_WASTE, SHANTY_PUT_WASTE);
     if (commodityCount[STUFF_FOOD] >= SHANTY_GET_FOOD)
-    {   commodityCount[STUFF_FOOD] -= SHANTY_GET_FOOD;}
+    {   consumeStuff(STUFF_FOOD, SHANTY_GET_FOOD);}
     if (commodityCount[STUFF_JOBS] >= SHANTY_GET_JOBS)
     {
-        commodityCount[STUFF_JOBS] -= SHANTY_GET_JOBS;
+        consumeStuff(STUFF_JOBS, SHANTY_GET_JOBS);
         if ((income_tax -= SHANTY_GET_JOBS * 2) < 0)
         {   income_tax = 0;}
     }
     if (commodityCount[STUFF_GOODS] >= SHANTY_GET_GOODS)
     {
-        commodityCount[STUFF_GOODS] -= SHANTY_GET_GOODS;
-        commodityCount[STUFF_WASTE] += SHANTY_GET_GOODS / 3;
+        consumeStuff(STUFF_GOODS, SHANTY_GET_GOODS);
+        produceStuff(STUFF_WASTE, SHANTY_GET_GOODS / 3);
         if ((goods_tax -= SHANTY_GET_GOODS * 2) < 0)
         {   goods_tax = 0;}
     }
     if (commodityCount[STUFF_COAL] >= SHANTY_GET_COAL)
     {
-        commodityCount[STUFF_COAL] -= SHANTY_GET_COAL;
+        consumeStuff(STUFF_COAL, SHANTY_GET_COAL);
         if ((coal_tax -= SHANTY_GET_COAL * 2) < 0)
         {   coal_tax = 0;}
     }
     if (commodityCount[STUFF_ORE] >= SHANTY_GET_ORE)
-    {   commodityCount[STUFF_ORE] -= SHANTY_GET_ORE;}
+    {   consumeStuff(STUFF_ORE, SHANTY_GET_ORE);}
     if (commodityCount[STUFF_STEEL] >= SHANTY_GET_STEEL)
-    {   commodityCount[STUFF_STEEL] -= SHANTY_GET_STEEL;}
-    if ((commodityCount[STUFF_WASTE]+= SHANTY_PUT_WASTE) >= MAX_WASTE_AT_SHANTY && !world(x+1,y+1)->construction)
+    {   consumeStuff(STUFF_STEEL, SHANTY_GET_STEEL);}
+    produceStuff(STUFF_WASTE, SHANTY_PUT_WASTE);
+    if (commodityCount[STUFF_WASTE] >= MAX_WASTE_AT_SHANTY && !world(x+1,y+1)->construction)
     {
         anim = real_time + 3 * WASTE_BURN_TIME;
         world(x+1,y+1)->pollution += commodityCount[STUFF_WASTE];
-        commodityCount[STUFF_WASTE] = 0;
+        levelStuff(STUFF_WASTE, 0);
         if(!world(x+1,y+1)->construction)
         {
             Construction *fire = fireConstructionGroup.createConstruction(x+1, y+1);
@@ -173,6 +174,10 @@ void Shanty::update()
         world(x+1,y+1)->construction = NULL;
         world(x+1,y+1)->reportingConstruction = this;
     }
+
+    if(total_time % 100 == 99) {
+        reset_prod_counters();
+    }
 }
 
 void Shanty::report()
@@ -185,4 +190,3 @@ void Shanty::report()
 }
 
 /** @file lincity/modules/shanty.cpp */
-

--- a/src/lincity/modules/shanty.h
+++ b/src/lincity/modules/shanty.h
@@ -45,7 +45,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_FOOD].maxload = MAX_FOOD_AT_SHANTY;
         commodityRuleCount[STUFF_FOOD].take = true;
@@ -98,4 +99,3 @@ public:
 
 
 /** @file lincity/modules/shanty.h */
-

--- a/src/lincity/modules/shanty.h
+++ b/src/lincity/modules/shanty.h
@@ -88,6 +88,17 @@ public:
         initialize_commodities();
         this->flags |= FLAG_NEVER_EVACUATE;
         this->anim = 0;
+
+        commodityMaxProd[STUFF_WASTE] = 100 *
+          (SHANTY_PUT_WASTE * 2 + SHANTY_GET_GOODS / 3);
+        commodityMaxCons[STUFF_FOOD] = 100 * SHANTY_GET_FOOD;
+        commodityMaxCons[STUFF_JOBS] = 100 * SHANTY_GET_JOBS;
+        commodityMaxCons[STUFF_GOODS] = 100 * SHANTY_GET_GOODS;
+        commodityMaxCons[STUFF_COAL] = 100 * SHANTY_GET_COAL;
+        commodityMaxCons[STUFF_ORE] = 100 * SHANTY_GET_ORE;
+        commodityMaxCons[STUFF_STEEL] = 100 * SHANTY_GET_STEEL;
+        commodityMaxCons[STUFF_WASTE] = 100 *
+          (MAX_WASTE_AT_SHANTY /*+ SHANTY_PUT_WASTE*2 + SHANTY_GET_GOODS/3*/);
     }
     virtual ~Shanty() { }
     virtual void update();

--- a/src/lincity/modules/solar_power.cpp
+++ b/src/lincity/modules/solar_power.cpp
@@ -36,12 +36,13 @@ void SolarPower::update()
     if ((commodityCount[STUFF_JOBS] >= jobs_used)
      && (mwh_made >= POWERS_SOLAR_OUTPUT))
     {
-        commodityCount[STUFF_JOBS] -= jobs_used;
-        commodityCount[STUFF_MWH] += mwh_made;
+        consumeStuff(STUFF_JOBS, jobs_used);
+        produceStuff(STUFF_MWH, mwh_made);
         working_days += mwh_made;
     }
-    if (total_time % 100 == 0) //monthly update
+    if (total_time % 100 == 99) //monthly update
     {
+        reset_prod_counters();
         busy = working_days / mwh_output;
         working_days = 0;
     }
@@ -61,4 +62,3 @@ void SolarPower::report()
 }
 
 /** @file lincity/modules/solar_power.cpp */
-

--- a/src/lincity/modules/solar_power.cpp
+++ b/src/lincity/modules/solar_power.cpp
@@ -57,7 +57,7 @@ void SolarPower::report()
     mps_store_sfp(i++, N_("busy"), (busy));
     mps_store_sfp(i++, N_("Tech"), (tech * 100.0) / MAX_TECH_LEVEL);
     mps_store_sd(i++, N_("Output"), mwh_output);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/solar_power.h
+++ b/src/lincity/modules/solar_power.h
@@ -54,13 +54,23 @@ public:
         setMemberSaved(&this->tech, "tech");
         this->working_days = 0;
         this->busy = 0;
-        this->mwh_output = (int)(POWERS_SOLAR_OUTPUT + (((double)tech_level * POWERS_SOLAR_OUTPUT) / MAX_TECH_LEVEL));
-        setMemberSaved(&this->mwh_output, "mwh_output");
+        // this->mwh_output = (int)(POWERS_SOLAR_OUTPUT + (((double)tech_level * POWERS_SOLAR_OUTPUT) / MAX_TECH_LEVEL));
+        setMemberSaved(&this->mwh_output, "mwh_output"); // compatibility
         initialize_commodities();
 
         commodityMaxCons[STUFF_JOBS] = 100 * SOLAR_POWER_JOBS;
+        // commodityMaxCons[STUFF_MWH] = 100 * mwh_output;
+    }
+
+    virtual void initialize() override {
+        RegisteredConstruction::initialize();
+
+        this->mwh_output = (int)(POWERS_SOLAR_OUTPUT +
+          (((double)tech_level * POWERS_SOLAR_OUTPUT) / MAX_TECH_LEVEL));
+
         commodityMaxCons[STUFF_MWH] = 100 * mwh_output;
     }
+
     virtual void update();
     virtual void report();
     int  mwh_output;

--- a/src/lincity/modules/solar_power.h
+++ b/src/lincity/modules/solar_power.h
@@ -27,7 +27,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_SOLARPS;
@@ -66,4 +67,3 @@ public:
 
 
 /** @file lincity/modules/solar_power.h */
-

--- a/src/lincity/modules/solar_power.h
+++ b/src/lincity/modules/solar_power.h
@@ -57,6 +57,9 @@ public:
         this->mwh_output = (int)(POWERS_SOLAR_OUTPUT + (((double)tech_level * POWERS_SOLAR_OUTPUT) / MAX_TECH_LEVEL));
         setMemberSaved(&this->mwh_output, "mwh_output");
         initialize_commodities();
+
+        commodityMaxCons[STUFF_JOBS] = 100 * SOLAR_POWER_JOBS;
+        commodityMaxCons[STUFF_MWH] = 100 * mwh_output;
     }
     virtual void update();
     virtual void report();

--- a/src/lincity/modules/substation.cpp
+++ b/src/lincity/modules/substation.cpp
@@ -37,12 +37,13 @@ void Substation::update()
     if ( (use_MWH > 0)
      && (commodityCount[STUFF_KWH] <= MAX_KWH_AT_SUBSTATION-2 * use_MWH))
     {
-        commodityCount[STUFF_MWH] -= use_MWH;
-        commodityCount[STUFF_KWH] += 2 * use_MWH;
+        consumeStuff(STUFF_MWH, use_MWH);
+        produceStuff(STUFF_KWH, 2 * use_MWH);
         working_days += use_MWH;
     }
-    if (total_time % 100 == 0) //monthly update
+    if (total_time % 100 == 99) //monthly update
     {
+        reset_prod_counters();
         busy = working_days/SUBSTATION_MWH;
         working_days = 0;
     }

--- a/src/lincity/modules/substation.cpp
+++ b/src/lincity/modules/substation.cpp
@@ -65,7 +65,7 @@ void Substation::report()
     mps_store_sd(i++, constructionGroup->name, ID);
     i++;
     mps_store_sfp(i++, N_("busy"), busy);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/substation.h
+++ b/src/lincity/modules/substation.h
@@ -55,6 +55,9 @@ public:
         this->working_days = 0;
         this->busy = 0;
         initialize_commodities();
+
+        commodityMaxCons[STUFF_MWH] = 100 * SUBSTATION_MWH;
+        commodityMaxCons[STUFF_KWH] = 100 * 2 * SUBSTATION_MWH;
     }
     virtual ~Substation() { }
     virtual void update() override;

--- a/src/lincity/modules/substation.h
+++ b/src/lincity/modules/substation.h
@@ -57,7 +57,7 @@ public:
         initialize_commodities();
 
         commodityMaxCons[STUFF_MWH] = 100 * SUBSTATION_MWH;
-        commodityMaxCons[STUFF_KWH] = 100 * 2 * SUBSTATION_MWH;
+        commodityMaxProd[STUFF_KWH] = 100 * 2 * SUBSTATION_MWH;
     }
     virtual ~Substation() { }
     virtual void update() override;

--- a/src/lincity/modules/substation.h
+++ b/src/lincity/modules/substation.h
@@ -27,7 +27,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
 
         commodityRuleCount[STUFF_MWH].maxload = MAX_MWH_AT_SUBSTATION;

--- a/src/lincity/modules/tip.cpp
+++ b/src/lincity/modules/tip.cpp
@@ -39,7 +39,7 @@ void Tip::update()
     && (commodityCount[STUFF_WASTE]*100/TIP_TAKES_WASTE > CRITICAL_WASTE_LEVEL)
     && (total_waste + WASTE_BURRIED < MAX_WASTE_AT_TIP))
     {
-        commodityCount[STUFF_WASTE] -= WASTE_BURRIED;
+        consumeStuff(STUFF_WASTE, WASTE_BURRIED);
         total_waste += WASTE_BURRIED;
         working_days++;
     }
@@ -48,12 +48,13 @@ void Tip::update()
     && (total_waste > 0))
     {
         int waste_dug = (WASTE_BURRIED < total_waste)?WASTE_BURRIED:total_waste;
-        commodityCount[STUFF_WASTE] += waste_dug;
+        produceStuff(STUFF_WASTE, waste_dug);
         total_waste -= waste_dug;
         working_days++;
     }
-    if ((total_time % 100) == 0)
+    if ((total_time % 100) == 99)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/tip.cpp
+++ b/src/lincity/modules/tip.cpp
@@ -76,7 +76,7 @@ void Tip::report()
     mps_store_sfp(i++,N_("busy"), busy);
     mps_store_sd(i++, N_("Waste"), total_waste);
     mps_store_sfp(i++, N_("Filled"), (float)total_waste*100/MAX_WASTE_AT_TIP);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/tip.h
+++ b/src/lincity/modules/tip.h
@@ -30,7 +30,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         commodityRuleCount[STUFF_WASTE].maxload = TIP_TAKES_WASTE;

--- a/src/lincity/modules/tip.h
+++ b/src/lincity/modules/tip.h
@@ -59,8 +59,8 @@ public:
         setMemberSaved(&this->degration_days,"degration_days");
         initialize_commodities();
 
-        commodityMaxCons[STUFF_WASTE] = WASTE_BURRIED;
-        commodityMaxProd[STUFF_WASTE] = WASTE_BURRIED;
+        commodityMaxCons[STUFF_WASTE] = 100 * WASTE_BURRIED;
+        commodityMaxProd[STUFF_WASTE] = 100 * WASTE_BURRIED;
     }
     virtual ~Tip() { }
     virtual void update() override;

--- a/src/lincity/modules/tip.h
+++ b/src/lincity/modules/tip.h
@@ -58,6 +58,9 @@ public:
         this->degration_days = 0;
         setMemberSaved(&this->degration_days,"degration_days");
         initialize_commodities();
+
+        commodityMaxCons[STUFF_WASTE] = WASTE_BURRIED;
+        commodityMaxProd[STUFF_WASTE] = WASTE_BURRIED;
     }
     virtual ~Tip() { }
     virtual void update() override;

--- a/src/lincity/modules/track_road_rail.cpp
+++ b/src/lincity/modules/track_road_rail.cpp
@@ -118,8 +118,8 @@ void Transport::update()
                 world(x,y)->pollution += ROAD_POLLUTION;
             if ((total_time & ROAD_GOODS_USED_MASK) == 0 && commodityCount[STUFF_GOODS] > 0)
             {
-                --commodityCount[STUFF_GOODS];
-                ++commodityCount[STUFF_WASTE];
+                consumeStuff(STUFF_GOODS, 1);
+                produceStuff(STUFF_WASTE, 1);
             }
         break;
         case GROUP_RAIL:
@@ -129,30 +129,34 @@ void Transport::update()
                 world(x,y)->pollution += RAIL_POLLUTION;
             if ((total_time & RAIL_GOODS_USED_MASK) == 0 && commodityCount[STUFF_GOODS] > 0)
             {
-                --commodityCount[STUFF_GOODS];
-                ++commodityCount[STUFF_WASTE];
+                consumeStuff(STUFF_GOODS, 1);
+                produceStuff(STUFF_WASTE, 1);
             }
             if ((total_time & RAIL_STEEL_USED_MASK) == 0 && commodityCount[STUFF_STEEL] > 0)
             {
-                --commodityCount[STUFF_STEEL];
-                ++commodityCount[STUFF_WASTE];
+                consumeStuff(STUFF_STEEL, 1);
+                produceStuff(STUFF_WASTE, 1);
             }
         break;
     }
     if (commodityCount[STUFF_KWH] >= KWH_LOSS_ON_TRANSPORT)
     {
-        commodityCount[STUFF_KWH] -= KWH_LOSS_ON_TRANSPORT;
+        consumeStuff(STUFF_KWH, KWH_LOSS_ON_TRANSPORT);
     }
     else if (commodityCount[STUFF_KWH] > 0)
     {
-        --commodityCount[STUFF_KWH];
+        consumeStuff(STUFF_KWH, 1);
     }
 
     if (commodityCount[STUFF_WASTE] > 9 * constructionGroup->commodityRuleCount[STUFF_WASTE].maxload / 10)
     {
-        commodityCount[STUFF_WASTE] -= WASTE_BURN_ON_TRANSPORT;
+        consumeStuff(STUFF_WASTE, WASTE_BURN_ON_TRANSPORT);
         world(x,y)->pollution += WASTE_BURN_ON_TRANSPORT_POLLUTE;
         burning_waste_anim = true;
+    }
+
+    if(total_time % 100 == 99) {
+        reset_prod_counters();
     }
 }
 

--- a/src/lincity/modules/track_road_rail.cpp
+++ b/src/lincity/modules/track_road_rail.cpp
@@ -209,7 +209,7 @@ void Transport::report()
     else
     {
         mps_store_title(i++, _("Commodities") );
-        list_commodities(&i);
+        list_inventory(&i);
     }
 }
 

--- a/src/lincity/modules/track_road_rail.h
+++ b/src/lincity/modules/track_road_rail.h
@@ -17,7 +17,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     )
     {
         switch (group)

--- a/src/lincity/modules/track_road_rail.h
+++ b/src/lincity/modules/track_road_rail.h
@@ -183,6 +183,28 @@ public:
 
         initialize_commodities();
         this->trafficCount = this->commodityCount;
+
+        switch (constructionGroup->group) {
+        case GROUP_ROAD:
+        case GROUP_ROAD_BRIDGE:
+            commodityMaxCons[STUFF_GOODS] =
+              (100 - 1) / (ROAD_GOODS_USED_MASK + 1) + 1;
+            commodityMaxProd[STUFF_WASTE] =
+              (100 - 1) / (ROAD_GOODS_USED_MASK + 1) + 1;
+            break;
+        case GROUP_RAIL:
+        case GROUP_RAIL_BRIDGE:
+            commodityMaxCons[STUFF_GOODS] =
+              (100 - 1) / (RAIL_GOODS_USED_MASK + 1) + 1;
+            commodityMaxCons[STUFF_STEEL] =
+              (100 - 1) / (RAIL_STEEL_USED_MASK + 1) + 1;
+            commodityMaxProd[STUFF_WASTE] =
+              (100 - 1) / (RAIL_GOODS_USED_MASK + 1) + 1 +
+              (100 - 1) / (RAIL_STEEL_USED_MASK + 1) + 1;
+            break;
+        }
+        commodityMaxCons[STUFF_KWH] = 100 * KWH_LOSS_ON_TRANSPORT;
+        commodityMaxCons[STUFF_WASTE] = 100 * WASTE_BURN_ON_TRANSPORT;
     }
     ~Transport()
     {

--- a/src/lincity/modules/university.cpp
+++ b/src/lincity/modules/university.cpp
@@ -57,7 +57,7 @@ void University::report()
     i++;
     mps_store_sfp(i++, N_("busy"), busy);
     mps_store_sfp(i++, N_("Tech researched"), total_tech_made * 100.0 / MAX_TECH_LEVEL);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/university.cpp
+++ b/src/lincity/modules/university.cpp
@@ -34,16 +34,17 @@ void University::update()
     &&  commodityCount[STUFF_GOODS] >= UNIVERSITY_GOODS
     &&  commodityCount[STUFF_WASTE] + UNIVERSITY_GOODS / 3 <= MAX_WASTE_AT_UNIVERSITY)
     {
-        commodityCount[STUFF_JOBS] -= UNIVERSITY_JOBS;
-        commodityCount[STUFF_GOODS] -= UNIVERSITY_GOODS;
-        commodityCount[STUFF_WASTE] += UNIVERSITY_GOODS / 3;
+        consumeStuff(STUFF_JOBS, UNIVERSITY_JOBS);
+        consumeStuff(STUFF_GOODS, UNIVERSITY_GOODS);
+        produceStuff(STUFF_WASTE, UNIVERSITY_GOODS / 3);
         ++working_days;
         tech_level += UNIVERSITY_TECH_MADE;
         total_tech_made += UNIVERSITY_TECH_MADE;
     }
     //monthly update
-    if ((total_time % 100) == 0)
+    if ((total_time % 100) == 99)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }
@@ -62,4 +63,3 @@ void University::report()
 
 
 /** @file lincity/modules/university.cpp */
-

--- a/src/lincity/modules/university.h
+++ b/src/lincity/modules/university.h
@@ -31,7 +31,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_UNIVERSITY;
         commodityRuleCount[STUFF_JOBS].take = true;
@@ -71,4 +72,3 @@ public:
 
 
 /** @file lincity/modules/university.h */
-

--- a/src/lincity/modules/university.h
+++ b/src/lincity/modules/university.h
@@ -61,6 +61,10 @@ public:
         this->total_tech_made = 0;
         setMemberSaved(&this->total_tech_made, "total_tech_made");
         initialize_commodities();
+
+        commodityMaxCons[STUFF_JOBS] = 100 * UNIVERSITY_JOBS;
+        commodityMaxCons[STUFF_GOODS] = 100 * UNIVERSITY_GOODS;
+        commodityMaxProd[STUFF_WASTE] = 100 * (UNIVERSITY_GOODS/3);
     }
     virtual ~University() { }
     virtual void update();

--- a/src/lincity/modules/waterwell.cpp
+++ b/src/lincity/modules/waterwell.cpp
@@ -42,11 +42,12 @@ void Waterwell::update()
     if(commodityCount[STUFF_WATER] + water_output <= MAX_WATER_AT_WATERWELL)
     {
         working_days++;
-        commodityCount[STUFF_WATER] += water_output;
+        produceStuff(STUFF_WATER, water_output);
     }
     //monthly update
-    if ((total_time % 100) == 0)
+    if ((total_time % 100) == 99)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }
@@ -69,4 +70,3 @@ void Waterwell::report()
 }
 
 /** @file lincity/modules/waterwell.cpp */
-

--- a/src/lincity/modules/waterwell.h
+++ b/src/lincity/modules/waterwell.h
@@ -22,7 +22,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_WATER].maxload = MAX_WATER_AT_WATERWELL;
         commodityRuleCount[STUFF_WATER].give = true;
@@ -66,4 +67,3 @@ public:
 };
 
 /** @file lincity/modules/waterwell.h */
-

--- a/src/lincity/modules/waterwell.h
+++ b/src/lincity/modules/waterwell.h
@@ -55,6 +55,8 @@ public:
         }//end i
         this->ugwCount = w;
         this->water_output = w * WATER_PER_UGW;
+
+        commodityMaxProd[STUFF_WATER] = 100 * water_output;
     }
 
     virtual ~Waterwell() { }

--- a/src/lincity/modules/windmill.cpp
+++ b/src/lincity/modules/windmill.cpp
@@ -66,7 +66,7 @@ void Windmill::report()
     mps_store_sfp(i++, N_("busy"), float(busy) / kwh_output);
     mps_store_sfp(i++, N_("Tech"), (tech * 100.0) / MAX_TECH_LEVEL);
     mps_store_sd(i++, N_("Output"), kwh_output);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/windmill.cpp
+++ b/src/lincity/modules/windmill.cpp
@@ -36,16 +36,17 @@ void Windmill::update()
     if ((commodityCount[STUFF_JOBS] >= jobs_used)
      && (kwh_made >= WINDMILL_KWH))
     {
-        commodityCount[STUFF_JOBS] -= jobs_used;
-        commodityCount[STUFF_KWH] += kwh_made;
+        consumeStuff(STUFF_JOBS, jobs_used);
+        produceStuff(STUFF_KWH, kwh_made);
         animate_enable = true;
         working_days += kwh_made;
     }
     else
     {   animate_enable = false;}
     //monthly update
-    if (total_time % 100 == 0)
+    if (total_time % 100 == 99)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/windmill.h
+++ b/src/lincity/modules/windmill.h
@@ -62,6 +62,9 @@ public:
         this->kwh_output = (int)(WINDMILL_KWH + (((double)tech_level * WINDMILL_KWH) / MAX_TECH_LEVEL));
         setMemberSaved(&this->kwh_output, "kwh_output");
         initialize_commodities();
+
+        commodityMaxCons[STUFF_JOBS] = 100 * WINDMILL_JOBS;
+        commodityMaxProd[STUFF_KWH] = 100 * kwh_output;
     }
 
     virtual ~Windmill() { }

--- a/src/lincity/modules/windmill.h
+++ b/src/lincity/modules/windmill.h
@@ -31,7 +31,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_WINDMILL;
         commodityRuleCount[STUFF_JOBS].take = true;

--- a/src/lincity/modules/windmill.h
+++ b/src/lincity/modules/windmill.h
@@ -59,12 +59,21 @@ public:
         setMemberSaved(&this->tech, "tech");
         this->working_days = 0;
         this->busy = 0;
-        this->kwh_output = (int)(WINDMILL_KWH + (((double)tech_level * WINDMILL_KWH) / MAX_TECH_LEVEL));
-        setMemberSaved(&this->kwh_output, "kwh_output");
+        // this->kwh_output = (int)(WINDMILL_KWH + (((double)tech_level * WINDMILL_KWH) / MAX_TECH_LEVEL));
+        setMemberSaved(&this->kwh_output, "kwh_output"); // compatibility
         initialize_commodities();
 
         commodityMaxCons[STUFF_JOBS] = 100 * WINDMILL_JOBS;
-        commodityMaxProd[STUFF_KWH] = 100 * kwh_output;
+        // commodityMaxProd[STUFF_KWH] = 100 * kwh_output;
+    }
+
+    virtual void initialize() override {
+      RegisteredConstruction::initialize();
+
+      this->kwh_output = (int)(WINDMILL_KWH +
+        (((double)tech_level * WINDMILL_KWH) / MAX_TECH_LEVEL));
+
+      commodityMaxProd[STUFF_KWH] = 100 * kwh_output;
     }
 
     virtual ~Windmill() { }

--- a/src/lincity/modules/windpower.cpp
+++ b/src/lincity/modules/windpower.cpp
@@ -38,16 +38,17 @@ void Windpower::update()
     if ((commodityCount[STUFF_JOBS] >= jobs_used)
      && mwh_made > WIND_POWER_MWH)
     {
-        commodityCount[STUFF_JOBS] -= jobs_used;
-        commodityCount[STUFF_MWH] += mwh_made;
+        consumeStuff(STUFF_JOBS, jobs_used);
+        produceStuff(STUFF_MWH, mwh_made);
         animate_enable = true;
         working_days += mwh_made;
     }
     else
     {   animate_enable = false;}
     //monthly update
-    if (total_time % 100 == 0)
+    if (total_time % 100 == 99)
     {
+        reset_prod_counters();
         busy = working_days;
         working_days = 0;
     }

--- a/src/lincity/modules/windpower.cpp
+++ b/src/lincity/modules/windpower.cpp
@@ -77,7 +77,7 @@ void Windpower::report()
     mps_store_sfp(i++, N_("busy"), float(busy) / mwh_output);
     mps_store_sfp(i++, N_("Tech"), (tech * 100.0) / MAX_TECH_LEVEL);
     mps_store_sd(i++, N_("Output"), mwh_output);
-    i++;
+    // i++;
     list_commodities(&i);
 }
 

--- a/src/lincity/modules/windpower.h
+++ b/src/lincity/modules/windpower.h
@@ -62,13 +62,23 @@ public:
         setMemberSaved(&this->tech, "tech");
         this->working_days = 0;
         this->busy = 0;
-        this->mwh_output = (int)(WIND_POWER_MWH + (((double)tech_level * WIND_POWER_MWH) / MAX_TECH_LEVEL));
-        setMemberSaved(&this->mwh_output, "mwh_output");
+        // this->mwh_output = (int)(WIND_POWER_MWH + (((double)tech_level * WIND_POWER_MWH) / MAX_TECH_LEVEL));
+        setMemberSaved(&this->mwh_output, "mwh_output"); // compatibility
         initialize_commodities();
 
         commodityMaxCons[STUFF_JOBS] = 100 * WIND_POWER_JOBS;
+        // commodityMaxProd[STUFF_MWH] = 100 * mwh_output;
+    }
+
+    virtual void initialize() override {
+        RegisteredConstruction::initialize();
+
+        this->mwh_output = (int)(WIND_POWER_MWH +
+          (((double)tech_level * WIND_POWER_MWH) / MAX_TECH_LEVEL));
+
         commodityMaxProd[STUFF_MWH] = 100 * mwh_output;
     }
+
     virtual ~Windpower() { }
     virtual void update() override;
     virtual void report() override;

--- a/src/lincity/modules/windpower.h
+++ b/src/lincity/modules/windpower.h
@@ -65,6 +65,9 @@ public:
         this->mwh_output = (int)(WIND_POWER_MWH + (((double)tech_level * WIND_POWER_MWH) / MAX_TECH_LEVEL));
         setMemberSaved(&this->mwh_output, "mwh_output");
         initialize_commodities();
+
+        commodityMaxCons[STUFF_JOBS] = 100 * WIND_POWER_JOBS;
+        commodityMaxCons[STUFF_MWH] = 100 * mwh_output;
     }
     virtual ~Windpower() { }
     virtual void update() override;

--- a/src/lincity/modules/windpower.h
+++ b/src/lincity/modules/windpower.h
@@ -67,7 +67,7 @@ public:
         initialize_commodities();
 
         commodityMaxCons[STUFF_JOBS] = 100 * WIND_POWER_JOBS;
-        commodityMaxCons[STUFF_MWH] = 100 * mwh_output;
+        commodityMaxProd[STUFF_MWH] = 100 * mwh_output;
     }
     virtual ~Windpower() { }
     virtual void update() override;

--- a/src/lincity/modules/windpower.h
+++ b/src/lincity/modules/windpower.h
@@ -32,7 +32,8 @@ public:
         int cost_mul, int bul_cost, int fire_chance,
         int cost, int tech, int range
     ): ConstructionGroup(
-        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance, cost, tech, range
+        name, no_credit, group, size, colour, cost_mul, bul_cost, fire_chance,
+        cost, tech, range, 2/*mps_pages*/
     ) {
         commodityRuleCount[STUFF_JOBS].maxload = MAX_JOBS_AT_WIND_POWER;
         commodityRuleCount[STUFF_JOBS].take = true;


### PR DESCRIPTION
Upgrades the MPS display paging system, and displays module production in a second MPS page.

- Allows each construction to have a different number of MPS pages.
- Displays last-month commodity production in a second MPS page for all constructions that produce/consume stuff.
- Streamlines the PBar diff system.
- Reduces the PBar diff moving average length to make it indicate month-to-month change.
- Adds an initialization stage for constructions after data is loaded from a save file.
- Separates construction creation from construction placement during load.
- Fixes an issue where parks inventory was not initialized.

When playing the game, I found the production report to be very useful for balancing production/consumption of commodities and for making sure that a construction is actually doing what I think it should be doing.