### PR TITLE
include CMake find modules for all SDL2 packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,22 @@ set(CMAKE_CXX_STANDARD 11 CACHE STRING "C++ standard")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/mk/cmake/modules)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+list(APPEND CMAKE_MODULE_PATH
+	${CMAKE_SOURCE_DIR}/mk/cmake/modules
+	${CMAKE_SOURCE_DIR}/mk/cmake/modules/SDL2
+)
 
 find_package(Threads)
 find_package(ZLIB REQUIRED)
 
-find_package(SDL2 CONFIG REQUIRED)
+find_package(SDL2 REQUIRED)
 find_package(SDL2_gfx REQUIRED)
-find_package(SDL2_image CONFIG REQUIRED)
-find_package(SDL2_mixer CONFIG REQUIRED)
-find_package(SDL2_ttf CONFIG REQUIRED)
+find_package(SDL2_image REQUIRED)
+find_package(SDL2_mixer REQUIRED)
+find_package(SDL2_ttf REQUIRED)
 find_package(LibXml2 REQUIRED)
-find_package(PhysFS REQUIRED)
+find_package(PhysFS MODULE REQUIRED) # config seems broken, so use module
 
 find_package(LibXslt REQUIRED)
 

--- a/mk/cmake/modules/SDL2/Copyright.txt
+++ b/mk/cmake/modules/SDL2/Copyright.txt
@@ -1,0 +1,132 @@
+CMake - Cross Platform Makefile Generator
+Copyright 2000-2019 Kitware, Inc. and Contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the name of Kitware, Inc. nor the names of Contributors
+  may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+
+The following individuals and institutions are among the Contributors:
+
+* Aaron C. Meadows <cmake@shadowguarddev.com>
+* Adriaan de Groot <groot@kde.org>
+* Aleksey Avdeev <solo@altlinux.ru>
+* Alexander Neundorf <neundorf@kde.org>
+* Alexander Smorkalov <alexander.smorkalov@itseez.com>
+* Alexey Sokolov <sokolov@google.com>
+* Alex Merry <alex.merry@kde.org>
+* Alex Turbov <i.zaufi@gmail.com>
+* Amine Ben Hassouna <amine.benhassouna@gmail.com>
+* Andreas Pakulat <apaku@gmx.de>
+* Andreas Schneider <asn@cryptomilk.org>
+* André Rigland Brodtkorb <Andre.Brodtkorb@ifi.uio.no>
+* Axel Huebl, Helmholtz-Zentrum Dresden - Rossendorf
+* Benjamin Eikel
+* Bjoern Ricks <bjoern.ricks@gmail.com>
+* Brad Hards <bradh@kde.org>
+* Christopher Harvey
+* Christoph Grüninger <foss@grueninger.de>
+* Clement Creusot <creusot@cs.york.ac.uk>
+* Daniel Blezek <blezek@gmail.com>
+* Daniel Pfeifer <daniel@pfeifer-mail.de>
+* Enrico Scholz <enrico.scholz@informatik.tu-chemnitz.de>
+* Eran Ifrah <eran.ifrah@gmail.com>
+* Esben Mose Hansen, Ange Optimization ApS
+* Geoffrey Viola <geoffrey.viola@asirobots.com>
+* Google Inc
+* Gregor Jasny
+* Helio Chissini de Castro <helio@kde.org>
+* Ilya Lavrenov <ilya.lavrenov@itseez.com>
+* Insight Software Consortium <insightsoftwareconsortium.org>
+* Jan Woetzel
+* Julien Schueller
+* Kelly Thompson <kgt@lanl.gov>
+* Laurent Montel <montel@kde.org>
+* Konstantin Podsvirov <konstantin@podsvirov.pro>
+* Mario Bensi <mbensi@ipsquad.net>
+* Martin Gräßlin <mgraesslin@kde.org>
+* Mathieu Malaterre <mathieu.malaterre@gmail.com>
+* Matthaeus G. Chajdas
+* Matthias Kretz <kretz@kde.org>
+* Matthias Maennich <matthias@maennich.net>
+* Michael Hirsch, Ph.D. <www.scivision.co>
+* Michael Stürmer
+* Miguel A. Figueroa-Villanueva
+* Mike Jackson
+* Mike McQuaid <mike@mikemcquaid.com>
+* Nicolas Bock <nicolasbock@gmail.com>
+* Nicolas Despres <nicolas.despres@gmail.com>
+* Nikita Krupen'ko <krnekit@gmail.com>
+* NVIDIA Corporation <www.nvidia.com>
+* OpenGamma Ltd. <opengamma.com>
+* Patrick Stotko <stotko@cs.uni-bonn.de>
+* Per Øyvind Karlsen <peroyvind@mandriva.org>
+* Peter Collingbourne <peter@pcc.me.uk>
+* Petr Gotthard <gotthard@honeywell.com>
+* Philip Lowman <philip@yhbt.com>
+* Philippe Proulx <pproulx@efficios.com>
+* Raffi Enficiaud, Max Planck Society
+* Raumfeld <raumfeld.com>
+* Roger Leigh <rleigh@codelibre.net>
+* Rolf Eike Beer <eike@sf-mail.de>
+* Roman Donchenko <roman.donchenko@itseez.com>
+* Roman Kharitonov <roman.kharitonov@itseez.com>
+* Ruslan Baratov
+* Sebastian Holtermann <sebholt@xwmw.org>
+* Stephen Kelly <steveire@gmail.com>
+* Sylvain Joubert <joubert.sy@gmail.com>
+* Thomas Sondergaard <ts@medical-insight.com>
+* Tobias Hunger <tobias.hunger@qt.io>
+* Todd Gamblin <tgamblin@llnl.gov>
+* Tristan Carel
+* University of Dundee
+* Vadim Zhukov
+* Will Dicharry <wdicharry@stellarscience.com>
+
+See version control history for details of individual contributions.
+
+The above copyright and license notice applies to distributions of
+CMake in source and binary form.  Third-party software packages supplied
+with CMake under compatible licenses provide their own copyright notices
+documented in corresponding subdirectories or source files.
+
+------------------------------------------------------------------------------
+
+CMake was initially developed by Kitware with the following sponsorship:
+
+ * National Library of Medicine at the National Institutes of Health
+   as part of the Insight Segmentation and Registration Toolkit (ITK).
+
+ * US National Labs (Los Alamos, Livermore, Sandia) ASC Parallel
+   Visualization Initiative.
+
+ * National Alliance for Medical Image Computing (NAMIC) is funded by the
+   National Institutes of Health through the NIH Roadmap for Medical Research,
+   Grant U54 EB005149.
+
+ * Kitware, Inc.

--- a/mk/cmake/modules/SDL2/FindSDL2.cmake
+++ b/mk/cmake/modules/SDL2/FindSDL2.cmake
@@ -1,0 +1,390 @@
+# Adapted from https://github.com/aminosbh/sdl2-cmake-modules
+
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#  Copyright 2019 Amine Ben Hassouna <amine.benhassouna@gmail.com>
+#  Copyright 2000-2019 Kitware, Inc. and Contributors
+#  All rights reserved.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+#  * Neither the name of Kitware, Inc. nor the names of Contributors
+#    may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindSDL2
+--------
+
+Locate SDL2 library
+
+This module defines the following 'IMPORTED' targets:
+
+::
+
+  SDL2::Core
+    The SDL2 library, if found.
+    Libraries should link to SDL2::Core
+
+  SDL2::Main
+    The SDL2main library, if found.
+    Applications should link to SDL2::Main instead of SDL2::Core
+
+
+
+This module will set the following variables in your project:
+
+::
+
+  SDL2_LIBRARIES, the name of the library to link against
+  SDL2_INCLUDE_DIRS, where to find SDL.h
+  SDL2_FOUND, if false, do not try to link to SDL2
+  SDL2MAIN_FOUND, if false, do not try to link to SDL2main
+  SDL2_VERSION_STRING, human-readable string containing the version of SDL2
+
+
+
+This module responds to the following cache variables:
+
+::
+
+  SDL2_PATH
+    Set a custom SDL2 Library path (default: empty)
+
+  SDL2_NO_DEFAULT_PATH
+    Disable search SDL2 Library in default path.
+      If SDL2_PATH (default: ON)
+      Else (default: OFF)
+
+  SDL2_INCLUDE_DIR
+    SDL2 headers path.
+
+  SDL2_LIBRARY
+    SDL2 Library (.dll, .so, .a, etc) path.
+
+  SDL2MAIN_LIBRAY
+    SDL2main Library (.a) path.
+
+  SDL2_BUILDING_LIBRARY
+    This flag is useful only when linking to SDL2_LIBRARIES insead of
+    SDL2::Main. It is required only when building a library that links to
+    SDL2_LIBRARIES, because only applications need main() (No need to also
+    link to SDL2main).
+    If this flag is defined, then no SDL2main will be added to SDL2_LIBRARIES
+    and no SDL2::Main target will be created.
+
+
+Don't forget to include SDLmain.h and SDLmain.m in your project for the
+OS X framework based version. (Other versions link to -lSDL2main which
+this module will try to find on your behalf.) Also for OS X, this
+module will automatically add the -framework Cocoa on your behalf.
+
+
+Additional Note: If you see an empty SDL2_LIBRARY in your project
+configuration, it means CMake did not find your SDL2 library
+(SDL2.dll, libsdl2.so, SDL2.framework, etc). Set SDL2_LIBRARY to point
+to your SDL2 library, and  configure again. Similarly, if you see an
+empty SDL2MAIN_LIBRARY, you should set this value as appropriate. These
+values are used to generate the final SDL2_LIBRARIES variable and the
+SDL2::Core and SDL2::Main targets, but when these values are unset,
+SDL2_LIBRARIES, SDL2::Core and SDL2::Main does not get created.
+
+
+$SDL2DIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2DIR used in building SDL2.  l.e.galup 9-20-02
+
+
+
+Created by Amine Ben Hassouna:
+  Adapt FindSDL.cmake to SDL2 (FindSDL2.cmake).
+  Add cache variables for more flexibility:
+    SDL2_PATH, SDL2_NO_DEFAULT_PATH (for details, see doc above).
+  Mark 'Threads' as a required dependency for non-OSX systems.
+  Modernize the FindSDL2.cmake module by creating specific targets:
+    SDL2::Core and SDL2::Main (for details, see doc above).
+
+
+Original FindSDL.cmake module:
+  Modified by Eric Wing.  Added code to assist with automated building
+  by using environmental variables and providing a more
+  controlled/consistent search behavior.  Added new modifications to
+  recognize OS X frameworks and additional Unix paths (FreeBSD, etc).
+  Also corrected the header search path to follow "proper" SDL
+  guidelines.  Added a search for SDLmain which is needed by some
+  platforms.  Added a search for threads which is needed by some
+  platforms.  Added needed compile switches for MinGW.
+
+On OSX, this will prefer the Framework version (if found) over others.
+People will have to manually change the cache value of SDL2_LIBRARY to
+override this selection or set the SDL2_PATH variable or the CMake
+environment CMAKE_INCLUDE_PATH to modify the search paths.
+
+Note that the header path has changed from SDL/SDL.h to just SDL.h
+This needed to change because "proper" SDL convention is #include
+"SDL.h", not <SDL/SDL.h>.  This is done for portability reasons
+because not all systems place things in SDL/ (see FreeBSD).
+#]=======================================================================]
+
+# Define options for searching SDL2 Library in a custom path
+
+set(SDL2_PATH "" CACHE STRING "Custom SDL2 Library path")
+
+set(_SDL2_NO_DEFAULT_PATH OFF)
+if(SDL2_PATH)
+  set(_SDL2_NO_DEFAULT_PATH ON)
+endif()
+
+set(SDL2_NO_DEFAULT_PATH ${_SDL2_NO_DEFAULT_PATH}
+    CACHE BOOL "Disable search SDL2 Library in default path")
+unset(_SDL2_NO_DEFAULT_PATH)
+
+set(SDL2_NO_DEFAULT_PATH_CMD)
+if(SDL2_NO_DEFAULT_PATH)
+  set(SDL2_NO_DEFAULT_PATH_CMD NO_DEFAULT_PATH)
+endif()
+
+# Search for the SDL2 include directory
+find_path(SDL2_INCLUDE_DIR SDL.h
+  HINTS
+    ENV SDL2DIR
+    ${SDL2_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                include/SDL2 include
+  PATHS ${SDL2_PATH}
+  DOC "Where the SDL2 headers can be found"
+)
+
+set(SDL2_INCLUDE_DIRS "${SDL2_INCLUDE_DIR}")
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+# SDL-2.0 is the name used by FreeBSD ports...
+# don't confuse it for the version number.
+find_library(SDL2_LIBRARY
+  NAMES SDL2 SDL-2.0
+  HINTS
+    ENV SDL2DIR
+    ${SDL2_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+  PATHS ${SDL2_PATH}
+  DOC "Where the SDL2 Library can be found"
+)
+
+set(SDL2_LIBRARIES "${SDL2_LIBRARY}")
+
+if(NOT SDL2_BUILDING_LIBRARY)
+  if(NOT SDL2_INCLUDE_DIR MATCHES ".framework")
+    # Non-OS X framework versions expect you to also dynamically link to
+    # SDL2main. This is mainly for Windows and OS X. Other (Unix) platforms
+    # seem to provide SDL2main for compatibility even though they don't
+    # necessarily need it.
+
+    if(SDL2_PATH)
+      set(SDL2MAIN_LIBRARY_PATHS "${SDL2_PATH}")
+    endif()
+
+    if(NOT SDL2_NO_DEFAULT_PATH)
+      set(SDL2MAIN_LIBRARY_PATHS
+            /sw
+            /opt/local
+            /opt/csw
+            /opt
+            "${SDL2MAIN_LIBRARY_PATHS}"
+      )
+    endif()
+
+    find_library(SDL2MAIN_LIBRARY
+      NAMES SDL2main
+      HINTS
+        ENV SDL2DIR
+        ${SDL2_NO_DEFAULT_PATH_CMD}
+      PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+      PATHS ${SDL2MAIN_LIBRARY_PATHS}
+      DOC "Where the SDL2main library can be found"
+    )
+    unset(SDL2MAIN_LIBRARY_PATHS)
+  endif()
+endif()
+
+# SDL2 may require threads on your system.
+# The Apple build may not need an explicit flag because one of the
+# frameworks may already provide it.
+# But for non-OSX systems, I will use the CMake Threads package.
+if(NOT APPLE)
+  find_package(Threads QUIET)
+  if(NOT Threads_FOUND)
+    set(SDL2_THREADS_NOT_FOUND "Could NOT find Threads (Threads is required by SDL2).")
+    if(SDL2_FIND_REQUIRED)
+      message(FATAL_ERROR ${SDL2_THREADS_NOT_FOUND})
+    else()
+        if(NOT SDL2_FIND_QUIETLY)
+          message(STATUS ${SDL2_THREADS_NOT_FOUND})
+        endif()
+      return()
+    endif()
+    unset(SDL2_THREADS_NOT_FOUND)
+  endif()
+endif()
+
+# MinGW needs an additional link flag, -mwindows
+# It's total link flags should look like -lmingw32 -lSDL2main -lSDL2 -mwindows
+if(MINGW)
+  set(MINGW32_LIBRARY mingw32 "-mwindows" CACHE STRING "link flags for MinGW")
+endif()
+
+if(SDL2_LIBRARY)
+  # For SDL2main
+  if(SDL2MAIN_LIBRARY AND NOT SDL2_BUILDING_LIBRARY)
+    list(FIND SDL2_LIBRARIES "${SDL2MAIN_LIBRARY}" _SDL2_MAIN_INDEX)
+    if(_SDL2_MAIN_INDEX EQUAL -1)
+      set(SDL2_LIBRARIES "${SDL2MAIN_LIBRARY}" ${SDL2_LIBRARIES})
+    endif()
+    unset(_SDL2_MAIN_INDEX)
+  endif()
+
+  # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+  # CMake doesn't display the -framework Cocoa string in the UI even
+  # though it actually is there if I modify a pre-used variable.
+  # I think it has something to do with the CACHE STRING.
+  # So I use a temporary variable until the end so I can set the
+  # "real" variable in one-shot.
+  if(APPLE)
+    set(SDL2_LIBRARIES ${SDL2_LIBRARIES} -framework Cocoa)
+  endif()
+
+  # For threads, as mentioned Apple doesn't need this.
+  # In fact, there seems to be a problem if I used the Threads package
+  # and try using this line, so I'm just skipping it entirely for OS X.
+  if(NOT APPLE)
+    set(SDL2_LIBRARIES ${SDL2_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+  endif()
+
+  # For MinGW library
+  if(MINGW)
+    set(SDL2_LIBRARIES ${MINGW32_LIBRARY} ${SDL2_LIBRARIES})
+  endif()
+
+endif()
+
+# Read SDL2 version
+if(SDL2_INCLUDE_DIR AND EXISTS "${SDL2_INCLUDE_DIR}/SDL_version.h")
+  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_INCLUDE_DIR}/SDL_version.h" SDL2_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_VERSION_MAJOR "${SDL2_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_VERSION_MINOR "${SDL2_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_VERSION_PATCH "${SDL2_VERSION_PATCH_LINE}")
+  set(SDL2_VERSION_STRING ${SDL2_VERSION_MAJOR}.${SDL2_VERSION_MINOR}.${SDL2_VERSION_PATCH})
+  unset(SDL2_VERSION_MAJOR_LINE)
+  unset(SDL2_VERSION_MINOR_LINE)
+  unset(SDL2_VERSION_PATCH_LINE)
+  unset(SDL2_VERSION_MAJOR)
+  unset(SDL2_VERSION_MINOR)
+  unset(SDL2_VERSION_PATCH)
+endif()
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2
+                                  REQUIRED_VARS SDL2_LIBRARY SDL2_INCLUDE_DIR
+                                  VERSION_VAR SDL2_VERSION_STRING)
+
+if(SDL2MAIN_LIBRARY)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2main
+                                    REQUIRED_VARS SDL2MAIN_LIBRARY SDL2_INCLUDE_DIR
+                                    VERSION_VAR SDL2_VERSION_STRING)
+endif()
+
+
+mark_as_advanced(SDL2_PATH
+                 SDL2_NO_DEFAULT_PATH
+                 SDL2_LIBRARY
+                 SDL2MAIN_LIBRARY
+                 SDL2_INCLUDE_DIR
+                 SDL2_BUILDING_LIBRARY)
+
+
+# SDL2:: targets (SDL2::SDL2 and SDL2::SDL2main)
+if(SDL2_FOUND)
+
+  # SDL2::SDL2 target
+  if(SDL2_LIBRARY AND NOT TARGET SDL2::SDL2)
+    add_library(SDL2::SDL2 UNKNOWN IMPORTED)
+    set_target_properties(SDL2::SDL2 PROPERTIES
+                          IMPORTED_LOCATION "${SDL2_LIBRARY}"
+                          INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIR}")
+
+    if(APPLE)
+      # For OS X, SDL2 uses Cocoa as a backend so it must link to Cocoa.
+      # For more details, please see above.
+      set_property(TARGET SDL2::SDL2 APPEND PROPERTY
+                   INTERFACE_LINK_OPTIONS -framework Cocoa)
+    else()
+      # For threads, as mentioned Apple doesn't need this.
+      # For more details, please see above.
+      set_property(TARGET SDL2::SDL2 APPEND PROPERTY
+                   INTERFACE_LINK_LIBRARIES Threads::Threads)
+    endif()
+  endif()
+
+  # SDL2::SDL2main target
+  # Applications should link to SDL2::SDL2main instead of SDL2::SDL2
+  # For more details, please see above.
+  if(NOT SDL2_BUILDING_LIBRARY AND NOT TARGET SDL2::SDL2main)
+
+    if(SDL2_INCLUDE_DIR MATCHES ".framework" OR NOT SDL2MAIN_LIBRARY)
+      add_library(SDL2::SDL2main INTERFACE IMPORTED)
+      set_property(TARGET SDL2::SDL2main PROPERTY
+                   INTERFACE_LINK_LIBRARIES SDL2::SDL2)
+    elseif(SDL2MAIN_LIBRARY)
+      # MinGW requires that the mingw32 library is specified before the
+      # libSDL2main.a static library when linking.
+      # The SDL2::MainInternal target is used internally to make sure that
+      # CMake respects this condition.
+      add_library(SDL2::MainInternal UNKNOWN IMPORTED)
+      set_property(TARGET SDL2::MainInternal PROPERTY
+                   IMPORTED_LOCATION "${SDL2MAIN_LIBRARY}")
+      set_property(TARGET SDL2::MainInternal PROPERTY
+                   INTERFACE_LINK_LIBRARIES SDL2::SDL2)
+
+      add_library(SDL2::SDL2main INTERFACE IMPORTED)
+
+      if(MINGW)
+        # MinGW needs an additional link flag '-mwindows' and link to mingw32
+        set_property(TARGET SDL2::SDL2main PROPERTY
+                     INTERFACE_LINK_LIBRARIES "mingw32" "-mwindows")
+      endif()
+
+      set_property(TARGET SDL2::SDL2main APPEND PROPERTY
+                   INTERFACE_LINK_LIBRARIES SDL2::MainInternal)
+    endif()
+
+  endif()
+endif()

--- a/mk/cmake/modules/SDL2/FindSDL2_gfx.cmake
+++ b/mk/cmake/modules/SDL2/FindSDL2_gfx.cmake
@@ -1,4 +1,4 @@
-# Adapted from https://github.com/aminosbh/sdl2-cmake-modules/blob/ad006a3daae65a612ed87415037e32188b81071e/FindSDL2_gfx.cmake
+# Adapted from https://github.com/aminosbh/sdl2-cmake-modules
 
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.

--- a/mk/cmake/modules/SDL2/FindSDL2_image.cmake
+++ b/mk/cmake/modules/SDL2/FindSDL2_image.cmake
@@ -1,0 +1,224 @@
+# Adapted from https://github.com/aminosbh/sdl2-cmake-modules
+
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#  Copyright 2019 Amine Ben Hassouna <amine.benhassouna@gmail.com>
+#  Copyright 2000-2019 Kitware, Inc. and Contributors
+#  All rights reserved.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+#  * Neither the name of Kitware, Inc. nor the names of Contributors
+#    may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindSDL2_image
+--------------
+
+Locate SDL2_image library
+
+This module defines the following 'IMPORTED' target:
+
+::
+
+  SDL2::Image
+    The SDL2_image library, if found.
+    Have SDL2::Core as a link dependency.
+
+
+
+This module will set the following variables in your project:
+
+::
+
+  SDL2_IMAGE_LIBRARIES, the name of the library to link against
+  SDL2_IMAGE_INCLUDE_DIRS, where to find the headers
+  SDL2_IMAGE_FOUND, if false, do not try to link against
+  SDL2_IMAGE_VERSION_STRING - human-readable string containing the
+                              version of SDL2_image
+
+
+
+This module responds to the following cache variables:
+
+::
+
+  SDL2_IMAGE_PATH
+    Set a custom SDL2_image Library path (default: empty)
+
+  SDL2_IMAGE_NO_DEFAULT_PATH
+    Disable search SDL2_image Library in default path.
+      If SDL2_IMAGE_PATH (default: ON)
+      Else (default: OFF)
+
+  SDL2_IMAGE_INCLUDE_DIR
+    SDL2_image headers path.
+
+  SDL2_IMAGE_LIBRARY
+    SDL2_image Library (.dll, .so, .a, etc) path.
+
+
+Additional Note: If you see an empty SDL2_IMAGE_LIBRARY in your project
+configuration, it means CMake did not find your SDL2_image library
+(SDL2_image.dll, libsdl2_image.so, etc). Set SDL2_IMAGE_LIBRARY to point
+to your SDL2_image library, and  configure again. This value is used to
+generate the final SDL2_IMAGE_LIBRARIES variable and the SDL2::Image target,
+but when this value is unset, SDL2_IMAGE_LIBRARIES and SDL2::Image does not
+get created.
+
+
+$SDL2IMAGEDIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2IMAGEDIR used in building SDL2_image.
+
+$SDL2DIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2DIR used in building SDL2.
+
+
+
+Created by Amine Ben Hassouna:
+  Adapt FindSDL_image.cmake to SDL2_image (FindSDL2_image.cmake).
+  Add cache variables for more flexibility:
+    SDL2_IMAGE_PATH, SDL2_IMAGE_NO_DEFAULT_PATH (for details, see doc above).
+  Add SDL2 as a required dependency.
+  Modernize the FindSDL2_image.cmake module by creating a specific target:
+    SDL2::Image (for details, see doc above).
+
+Original FindSDL_image.cmake module:
+  Created by Eric Wing.  This was influenced by the FindSDL.cmake
+  module, but with modifications to recognize OS X frameworks and
+  additional Unix paths (FreeBSD, etc).
+#]=======================================================================]
+
+# SDL2 Library required
+find_package(SDL2 QUIET)
+if(NOT SDL2_FOUND)
+  set(SDL2_IMAGE_SDL2_NOT_FOUND "Could NOT find SDL2 (SDL2 is required by SDL2_image).")
+  if(SDL2_image_FIND_REQUIRED)
+    message(FATAL_ERROR ${SDL2_IMAGE_SDL2_NOT_FOUND})
+  else()
+      if(NOT SDL2_image_FIND_QUIETLY)
+        message(STATUS ${SDL2_IMAGE_SDL2_NOT_FOUND})
+      endif()
+    return()
+  endif()
+  unset(SDL2_IMAGE_SDL2_NOT_FOUND)
+endif()
+
+
+# Define options for searching SDL2_image Library in a custom path
+
+set(SDL2_IMAGE_PATH "" CACHE STRING "Custom SDL2_image Library path")
+
+set(_SDL2_IMAGE_NO_DEFAULT_PATH OFF)
+if(SDL2_IMAGE_PATH)
+  set(_SDL2_IMAGE_NO_DEFAULT_PATH ON)
+endif()
+
+set(SDL2_IMAGE_NO_DEFAULT_PATH ${_SDL2_IMAGE_NO_DEFAULT_PATH}
+    CACHE BOOL "Disable search SDL2_image Library in default path")
+unset(_SDL2_IMAGE_NO_DEFAULT_PATH)
+
+set(SDL2_IMAGE_NO_DEFAULT_PATH_CMD)
+if(SDL2_IMAGE_NO_DEFAULT_PATH)
+  set(SDL2_IMAGE_NO_DEFAULT_PATH_CMD NO_DEFAULT_PATH)
+endif()
+
+# Search for the SDL2_image include directory
+find_path(SDL2_IMAGE_INCLUDE_DIR SDL_image.h
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+    ${SDL2_IMAGE_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                # and ENV{SDL2IMAGEDIR}
+                include/SDL2 include
+  PATHS ${SDL2_IMAGE_PATH}
+  DOC "Where the SDL2_image headers can be found"
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+# Search for the SDL2_image library
+find_library(SDL2_IMAGE_LIBRARY
+  NAMES SDL2_image
+  HINTS
+    ENV SDL2IMAGEDIR
+    ENV SDL2DIR
+    ${SDL2_IMAGE_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+  PATHS ${SDL2_IMAGE_PATH}
+  DOC "Where the SDL2_image Library can be found"
+)
+
+# Read SDL2_image version
+if(SDL2_IMAGE_INCLUDE_DIR AND EXISTS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_IMAGE_INCLUDE_DIR}/SDL_image.h" SDL2_IMAGE_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MAJOR "${SDL2_IMAGE_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_MINOR "${SDL2_IMAGE_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_IMAGE_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_IMAGE_VERSION_PATCH "${SDL2_IMAGE_VERSION_PATCH_LINE}")
+  set(SDL2_IMAGE_VERSION_STRING ${SDL2_IMAGE_VERSION_MAJOR}.${SDL2_IMAGE_VERSION_MINOR}.${SDL2_IMAGE_VERSION_PATCH})
+  unset(SDL2_IMAGE_VERSION_MAJOR_LINE)
+  unset(SDL2_IMAGE_VERSION_MINOR_LINE)
+  unset(SDL2_IMAGE_VERSION_PATCH_LINE)
+  unset(SDL2_IMAGE_VERSION_MAJOR)
+  unset(SDL2_IMAGE_VERSION_MINOR)
+  unset(SDL2_IMAGE_VERSION_PATCH)
+endif()
+
+set(SDL2_IMAGE_LIBRARIES ${SDL2_IMAGE_LIBRARY})
+set(SDL2_IMAGE_INCLUDE_DIRS ${SDL2_IMAGE_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_image
+                                  REQUIRED_VARS SDL2_IMAGE_LIBRARIES SDL2_IMAGE_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_IMAGE_VERSION_STRING)
+
+
+mark_as_advanced(SDL2_IMAGE_PATH
+                 SDL2_IMAGE_NO_DEFAULT_PATH
+                 SDL2_IMAGE_LIBRARY
+                 SDL2_IMAGE_INCLUDE_DIR)
+
+
+if(SDL2_IMAGE_FOUND)
+
+  # SDL2_image::SDL2_image target
+  if(SDL2_IMAGE_LIBRARY AND NOT TARGET SDL2_image::SDL2_image)
+    add_library(SDL2_image::SDL2_image UNKNOWN IMPORTED)
+    set_target_properties(SDL2_image::SDL2_image PROPERTIES
+                          IMPORTED_LOCATION "${SDL2_IMAGE_LIBRARY}"
+                          INTERFACE_INCLUDE_DIRECTORIES "${SDL2_IMAGE_INCLUDE_DIR}"
+                          INTERFACE_LINK_LIBRARIES $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>)
+  endif()
+endif()

--- a/mk/cmake/modules/SDL2/FindSDL2_mixer.cmake
+++ b/mk/cmake/modules/SDL2/FindSDL2_mixer.cmake
@@ -1,0 +1,222 @@
+# Adapted from https://github.com/aminosbh/sdl2-cmake-modules
+
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#  Copyright 2019 Amine Ben Hassouna <amine.benhassouna@gmail.com>
+#  Copyright 2000-2019 Kitware, Inc. and Contributors
+#  All rights reserved.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+#  * Neither the name of Kitware, Inc. nor the names of Contributors
+#    may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindSDL2_mixer
+--------------
+
+Locate SDL2_mixer library
+
+This module defines the following 'IMPORTED' target:
+
+::
+
+  SDL2::Mixer
+    The SDL2_mixer library, if found.
+    Have SDL2::Core as a link dependency.
+
+
+
+This module will set the following variables in your project:
+
+::
+
+  SDL2_MIXER_LIBRARIES, the name of the library to link against
+  SDL2_MIXER_INCLUDE_DIRS, where to find the headers
+  SDL2_MIXER_FOUND, if false, do not try to link against
+  SDL2_MIXER_VERSION_STRING - human-readable string containing the
+                              version of SDL2_mixer
+
+This module responds to the following cache variables:
+
+::
+
+  SDL2_MIXER_PATH
+    Set a custom SDL2_mixer Library path (default: empty)
+
+  SDL2_MIXER_NO_DEFAULT_PATH
+    Disable search SDL2_mixer Library in default path.
+      If SDL2_MIXER_PATH (default: ON)
+      Else (default: OFF)
+
+  SDL2_MIXER_INCLUDE_DIR
+    SDL2_mixer headers path.
+
+  SDL2_MIXER_LIBRARY
+    SDL2_mixer Library (.dll, .so, .a, etc) path.
+
+
+Additional Note: If you see an empty SDL2_MIXER_LIBRARY in your project
+configuration, it means CMake did not find your SDL2_mixer library
+(SDL2_mixer.dll, libsdl2_mixer.so, etc). Set SDL2_MIXER_LIBRARY to point
+to your SDL2_mixer library, and  configure again. This value is used to
+generate the final SDL2_MIXER_LIBRARIES variable and the SDL2::Mixer target,
+but when this value is unset, SDL2_MIXER_LIBRARIES and SDL2::Mixer does not
+get created.
+
+
+$SDL2MIXERDIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2MIXERDIR used in building SDL2_mixer.
+
+$SDL2DIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2DIR used in building SDL2.
+
+
+
+Created by Amine Ben Hassouna:
+  Adapt FindSDL_mixer.cmake to SDL2_mixer (FindSDL2_mixer.cmake).
+  Add cache variables for more flexibility:
+    SDL2_MIXER_PATH, SDL2_MIXER_NO_DEFAULT_PATH (for details, see doc above).
+  Add SDL2 as a required dependency.
+  Modernize the FindSDL2_mixer.cmake module by creating a specific target:
+    SDL2::Mixer (for details, see doc above).
+
+Original FindSDL_mixer.cmake module:
+  Created by Eric Wing.  This was influenced by the FindSDL.cmake
+  module, but with modifications to recognize OS X frameworks and
+  additional Unix paths (FreeBSD, etc).
+#]=======================================================================]
+
+# SDL2 Library required
+find_package(SDL2 QUIET)
+if(NOT SDL2_FOUND)
+  set(SDL2_MIXER_SDL2_NOT_FOUND "Could NOT find SDL2 (SDL2 is required by SDL2_mixer).")
+  if(SDL2_mixer_FIND_REQUIRED)
+    message(FATAL_ERROR ${SDL2_MIXER_SDL2_NOT_FOUND})
+  else()
+      if(NOT SDL2_mixer_FIND_QUIETLY)
+        message(STATUS ${SDL2_MIXER_SDL2_NOT_FOUND})
+      endif()
+    return()
+  endif()
+  unset(SDL2_MIXER_SDL2_NOT_FOUND)
+endif()
+
+
+# Define options for searching SDL2_mixer Library in a custom path
+
+set(SDL2_MIXER_PATH "" CACHE STRING "Custom SDL2_mixer Library path")
+
+set(_SDL2_MIXER_NO_DEFAULT_PATH OFF)
+if(SDL2_MIXER_PATH)
+  set(_SDL2_MIXER_NO_DEFAULT_PATH ON)
+endif()
+
+set(SDL2_MIXER_NO_DEFAULT_PATH ${_SDL2_MIXER_NO_DEFAULT_PATH}
+    CACHE BOOL "Disable search SDL2_mixer Library in default path")
+unset(_SDL2_MIXER_NO_DEFAULT_PATH)
+
+set(SDL2_MIXER_NO_DEFAULT_PATH_CMD)
+if(SDL2_MIXER_NO_DEFAULT_PATH)
+  set(SDL2_MIXER_NO_DEFAULT_PATH_CMD NO_DEFAULT_PATH)
+endif()
+
+# Search for the SDL2_mixer include directory
+find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
+  HINTS
+    ENV SDL2MIXERDIR
+    ENV SDL2DIR
+    ${SDL2_MIXER_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                # and ENV{SDL2MIXERDIR}
+                include/SDL2 include
+  PATHS ${SDL2_MIXER_PATH}
+  DOC "Where the SDL2_mixer headers can be found"
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+# Search for the SDL2_mixer library
+find_library(SDL2_MIXER_LIBRARY
+  NAMES SDL2_mixer
+  HINTS
+    ENV SDL2MIXERDIR
+    ENV SDL2DIR
+    ${SDL2_MIXER_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+  PATHS ${SDL2_MIXER_PATH}
+  DOC "Where the SDL2_mixer Library can be found"
+)
+
+# Read SDL2_mixer version
+if(SDL2_MIXER_INCLUDE_DIR AND EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_MAJOR "${SDL2_MIXER_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_MINOR "${SDL2_MIXER_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_PATCH "${SDL2_MIXER_VERSION_PATCH_LINE}")
+  set(SDL2_MIXER_VERSION_STRING ${SDL2_MIXER_VERSION_MAJOR}.${SDL2_MIXER_VERSION_MINOR}.${SDL2_MIXER_VERSION_PATCH})
+  unset(SDL2_MIXER_VERSION_MAJOR_LINE)
+  unset(SDL2_MIXER_VERSION_MINOR_LINE)
+  unset(SDL2_MIXER_VERSION_PATCH_LINE)
+  unset(SDL2_MIXER_VERSION_MAJOR)
+  unset(SDL2_MIXER_VERSION_MINOR)
+  unset(SDL2_MIXER_VERSION_PATCH)
+endif()
+
+set(SDL2_MIXER_LIBRARIES ${SDL2_MIXER_LIBRARY})
+set(SDL2_MIXER_INCLUDE_DIRS ${SDL2_MIXER_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_mixer
+                                  REQUIRED_VARS SDL2_MIXER_LIBRARIES SDL2_MIXER_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_MIXER_VERSION_STRING)
+
+
+mark_as_advanced(SDL2_MIXER_PATH
+                 SDL2_MIXER_NO_DEFAULT_PATH
+                 SDL2_MIXER_LIBRARY
+                 SDL2_MIXER_INCLUDE_DIR)
+
+
+if(SDL2_MIXER_FOUND)
+
+  # SDL2_mixer::SDL2_mixer target
+  if(SDL2_MIXER_LIBRARY AND NOT TARGET SDL2_mixer::SDL2_mixer)
+    add_library(SDL2_mixer::SDL2_mixer UNKNOWN IMPORTED)
+    set_target_properties(SDL2_mixer::SDL2_mixer PROPERTIES
+                          IMPORTED_LOCATION "${SDL2_MIXER_LIBRARY}"
+                          INTERFACE_INCLUDE_DIRECTORIES "${SDL2_MIXER_INCLUDE_DIR}"
+                          INTERFACE_LINK_LIBRARIES $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>)
+  endif()
+endif()

--- a/mk/cmake/modules/SDL2/FindSDL2_net.cmake
+++ b/mk/cmake/modules/SDL2/FindSDL2_net.cmake
@@ -1,0 +1,224 @@
+# Adapted from https://github.com/aminosbh/sdl2-cmake-modules
+
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#  Copyright 2019 Amine Ben Hassouna <amine.benhassouna@gmail.com>
+#  Copyright 2000-2019 Kitware, Inc. and Contributors
+#  All rights reserved.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+#  * Neither the name of Kitware, Inc. nor the names of Contributors
+#    may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindSDL2_net
+------------
+
+Locate SDL2_net library
+
+This module defines the following 'IMPORTED' target:
+
+::
+
+  SDL2::Net
+    The SDL2_net library, if found.
+    Have SDL2::Core as a link dependency.
+
+
+
+This module will set the following variables in your project:
+
+::
+
+  SDL2_NET_LIBRARIES, the name of the library to link against
+  SDL2_NET_INCLUDE_DIRS, where to find the headers
+  SDL2_NET_FOUND, if false, do not try to link against
+  SDL2_NET_VERSION_STRING - human-readable string containing the
+                            version of SDL2_net
+
+
+
+This module responds to the following cache variables:
+
+::
+
+  SDL2_NET_PATH
+    Set a custom SDL2_net Library path (default: empty)
+
+  SDL2_NET_NO_DEFAULT_PATH
+    Disable search SDL2_net Library in default path.
+      If SDL2_NET_PATH (default: ON)
+      Else (default: OFF)
+
+  SDL2_NET_INCLUDE_DIR
+    SDL2_net headers path.
+
+  SDL2_NET_LIBRARY
+    SDL2_net Library (.dll, .so, .a, etc) path.
+
+
+Additional Note: If you see an empty SDL2_NET_LIBRARY in your project
+configuration, it means CMake did not find your SDL2_net library
+(SDL2_net.dll, libsdl2_net.so, etc). Set SDL2_NET_LIBRARY to point
+to your SDL2_net library, and  configure again. This value is used to
+generate the final SDL2_NET_LIBRARIES variable and the SDL2::Net target,
+but when this value is unset, SDL2_NET_LIBRARIES and SDL2::Net does not
+get created.
+
+
+$SDL2NETDIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2NETDIR used in building SDL2_net.
+
+$SDL2DIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2DIR used in building SDL2.
+
+
+
+Created by Amine Ben Hassouna:
+  Adapt FindSDL_net.cmake to SDL2_net (FindSDL2_net.cmake).
+  Add cache variables for more flexibility:
+    SDL2_NET_PATH, SDL2_NET_NO_DEFAULT_PATH (for details, see doc above).
+  Add SDL2 as a required dependency.
+  Modernize the FindSDL2_net.cmake module by creating a specific target:
+    SDL2::Net (for details, see doc above).
+
+Original FindSDL_net.cmake module:
+  Created by Eric Wing.  This was influenced by the FindSDL.cmake
+  module, but with modifications to recognize OS X frameworks and
+  additional Unix paths (FreeBSD, etc).
+#]=======================================================================]
+
+# SDL2 Library required
+find_package(SDL2 QUIET)
+if(NOT SDL2_FOUND)
+  set(SDL2_NET_SDL2_NOT_FOUND "Could NOT find SDL2 (SDL2 is required by SDL2_net).")
+  if(SDL2_net_FIND_REQUIRED)
+    message(FATAL_ERROR ${SDL2_NET_SDL2_NOT_FOUND})
+  else()
+      if(NOT SDL2_net_FIND_QUIETLY)
+        message(STATUS ${SDL2_NET_SDL2_NOT_FOUND})
+      endif()
+    return()
+  endif()
+  unset(SDL2_NET_SDL2_NOT_FOUND)
+endif()
+
+
+# Define options for searching SDL2_net Library in a custom path
+
+set(SDL2_NET_PATH "" CACHE STRING "Custom SDL2_net Library path")
+
+set(_SDL2_NET_NO_DEFAULT_PATH OFF)
+if(SDL2_NET_PATH)
+  set(_SDL2_NET_NO_DEFAULT_PATH ON)
+endif()
+
+set(SDL2_NET_NO_DEFAULT_PATH ${_SDL2_NET_NO_DEFAULT_PATH}
+    CACHE BOOL "Disable search SDL2_net Library in default path")
+unset(_SDL2_NET_NO_DEFAULT_PATH)
+
+set(SDL2_NET_NO_DEFAULT_PATH_CMD)
+if(SDL2_NET_NO_DEFAULT_PATH)
+  set(SDL2_NET_NO_DEFAULT_PATH_CMD NO_DEFAULT_PATH)
+endif()
+
+# Search for the SDL2_net include directory
+find_path(SDL2_NET_INCLUDE_DIR SDL_net.h
+  HINTS
+    ENV SDL2NETDIR
+    ENV SDL2DIR
+    ${SDL2_NET_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                # and ENV{SDL2NETDIR}
+                include/SDL2 include
+  PATHS ${SDL2_NET_PATH}
+  DOC "Where the SDL2_net headers can be found"
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+# Search for the SDL2_net library
+find_library(SDL2_NET_LIBRARY
+  NAMES SDL2_net
+  HINTS
+    ENV SDL2NETDIR
+    ENV SDL2DIR
+    ${SDL2_NET_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+  PATHS ${SDL2_NET_PATH}
+  DOC "Where the SDL2_net Library can be found"
+)
+
+# Read SDL2_net version
+if(SDL2_NET_INCLUDE_DIR AND EXISTS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h")
+  file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL2_NET_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_NET_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL2_NET_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_NET_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_NET_INCLUDE_DIR}/SDL_net.h" SDL2_NET_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_NET_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_NET_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_NET_VERSION_MAJOR "${SDL2_NET_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_NET_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_NET_VERSION_MINOR "${SDL2_NET_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_NET_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_NET_VERSION_PATCH "${SDL2_NET_VERSION_PATCH_LINE}")
+  set(SDL2_NET_VERSION_STRING ${SDL2_NET_VERSION_MAJOR}.${SDL2_NET_VERSION_MINOR}.${SDL2_NET_VERSION_PATCH})
+  unset(SDL2_NET_VERSION_MAJOR_LINE)
+  unset(SDL2_NET_VERSION_MINOR_LINE)
+  unset(SDL2_NET_VERSION_PATCH_LINE)
+  unset(SDL2_NET_VERSION_MAJOR)
+  unset(SDL2_NET_VERSION_MINOR)
+  unset(SDL2_NET_VERSION_PATCH)
+endif()
+
+set(SDL2_NET_LIBRARIES ${SDL2_NET_LIBRARY})
+set(SDL2_NET_INCLUDE_DIRS ${SDL2_NET_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_net
+                                  REQUIRED_VARS SDL2_NET_LIBRARIES SDL2_NET_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_NET_VERSION_STRING)
+
+
+mark_as_advanced(SDL2_NET_PATH
+                 SDL2_NET_NO_DEFAULT_PATH
+                 SDL2_NET_LIBRARY
+                 SDL2_NET_INCLUDE_DIR)
+
+
+if(SDL2_NET_FOUND)
+
+  # SDL2_net::SDL2_net target
+  if(SDL2_NET_LIBRARY AND NOT TARGET SDL2_net::SDL2_net)
+    add_library(SDL2_net::SDL2_net UNKNOWN IMPORTED)
+    set_target_properties(SDL2_net::SDL2_net PROPERTIES
+                          IMPORTED_LOCATION "${SDL2_NET_LIBRARY}"
+                          INTERFACE_INCLUDE_DIRECTORIES "${SDL2_NET_INCLUDE_DIR}"
+                          INTERFACE_LINK_LIBRARIES $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>)
+  endif()
+endif()

--- a/mk/cmake/modules/SDL2/FindSDL2_ttf.cmake
+++ b/mk/cmake/modules/SDL2/FindSDL2_ttf.cmake
@@ -1,0 +1,224 @@
+# Adapted from https://github.com/aminosbh/sdl2-cmake-modules
+
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#  Copyright 2019 Amine Ben Hassouna <amine.benhassouna@gmail.com>
+#  Copyright 2000-2019 Kitware, Inc. and Contributors
+#  All rights reserved.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+#  * Neither the name of Kitware, Inc. nor the names of Contributors
+#    may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindSDL2_ttf
+------------
+
+Locate SDL2_ttf library
+
+This module defines the following 'IMPORTED' target:
+
+::
+
+  SDL2::TTF
+    The SDL2_ttf library, if found.
+    Have SDL2::Core as a link dependency.
+
+
+
+This module will set the following variables in your project:
+
+::
+
+  SDL2_TTF_LIBRARIES, the name of the library to link against
+  SDL2_TTF_INCLUDE_DIRS, where to find the headers
+  SDL2_TTF_FOUND, if false, do not try to link against
+  SDL2_TTF_VERSION_STRING - human-readable string containing the
+                            version of SDL2_ttf
+
+
+
+This module responds to the following cache variables:
+
+::
+
+  SDL2_TTF_PATH
+    Set a custom SDL2_ttf Library path (default: empty)
+
+  SDL2_TTF_NO_DEFAULT_PATH
+    Disable search SDL2_ttf Library in default path.
+      If SDL2_TTF_PATH (default: ON)
+      Else (default: OFF)
+
+  SDL2_TTF_INCLUDE_DIR
+    SDL2_ttf headers path.
+
+  SDL2_TTF_LIBRARY
+    SDL2_ttf Library (.dll, .so, .a, etc) path.
+
+
+Additional Note: If you see an empty SDL2_TTF_LIBRARY in your project
+configuration, it means CMake did not find your SDL2_ttf library
+(SDL2_ttf.dll, libsdl2_ttf.so, etc). Set SDL2_TTF_LIBRARY to point
+to your SDL2_ttf library, and  configure again. This value is used to
+generate the final SDL2_TTF_LIBRARIES variable and the SDL2::TTF target,
+but when this value is unset, SDL2_TTF_LIBRARIES and SDL2::TTF does not
+get created.
+
+
+$SDL2TTFDIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2TTFDIR used in building SDL2_ttf.
+
+$SDL2DIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2DIR used in building SDL2.
+
+
+
+Created by Amine Ben Hassouna:
+  Adapt FindSDL_ttf.cmake to SDL2_ttf (FindSDL2_ttf.cmake).
+  Add cache variables for more flexibility:
+    SDL2_TTF_PATH, SDL2_TTF_NO_DEFAULT_PATH (for details, see doc above).
+  Add SDL2 as a required dependency.
+  Modernize the FindSDL2_ttf.cmake module by creating a specific target:
+    SDL2::TTF (for details, see doc above).
+
+Original FindSDL_ttf.cmake module:
+  Created by Eric Wing.  This was influenced by the FindSDL.cmake
+  module, but with modifications to recognize OS X frameworks and
+  additional Unix paths (FreeBSD, etc).
+#]=======================================================================]
+
+# SDL2 Library required
+find_package(SDL2 QUIET)
+if(NOT SDL2_FOUND)
+  set(SDL2_TTF_SDL2_NOT_FOUND "Could NOT find SDL2 (SDL2 is required by SDL2_ttf).")
+  if(SDL2_ttf_FIND_REQUIRED)
+    message(FATAL_ERROR ${SDL2_TTF_SDL2_NOT_FOUND})
+  else()
+      if(NOT SDL2_ttf_FIND_QUIETLY)
+        message(STATUS ${SDL2_TTF_SDL2_NOT_FOUND})
+      endif()
+    return()
+  endif()
+  unset(SDL2_TTF_SDL2_NOT_FOUND)
+endif()
+
+
+# Define options for searching SDL2_ttf Library in a custom path
+
+set(SDL2_TTF_PATH "" CACHE STRING "Custom SDL2_ttf Library path")
+
+set(_SDL2_TTF_NO_DEFAULT_PATH OFF)
+if(SDL2_TTF_PATH)
+  set(_SDL2_TTF_NO_DEFAULT_PATH ON)
+endif()
+
+set(SDL2_TTF_NO_DEFAULT_PATH ${_SDL2_TTF_NO_DEFAULT_PATH}
+    CACHE BOOL "Disable search SDL2_ttf Library in default path")
+unset(_SDL2_TTF_NO_DEFAULT_PATH)
+
+set(SDL2_TTF_NO_DEFAULT_PATH_CMD)
+if(SDL2_TTF_NO_DEFAULT_PATH)
+  set(SDL2_TTF_NO_DEFAULT_PATH_CMD NO_DEFAULT_PATH)
+endif()
+
+# Search for the SDL2_ttf include directory
+find_path(SDL2_TTF_INCLUDE_DIR SDL_ttf.h
+  HINTS
+    ENV SDL2TTFDIR
+    ENV SDL2DIR
+    ${SDL2_TTF_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                # and ENV{SDL2TTFDIR}
+                include/SDL2 include
+  PATHS ${SDL2_TTF_PATH}
+  DOC "Where the SDL2_ttf headers can be found"
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+# Search for the SDL2_ttf library
+find_library(SDL2_TTF_LIBRARY
+  NAMES SDL2_ttf
+  HINTS
+    ENV SDL2TTFDIR
+    ENV SDL2DIR
+    ${SDL2_TTF_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+  PATHS ${SDL2_TTF_PATH}
+  DOC "Where the SDL2_ttf Library can be found"
+)
+
+# Read SDL2_ttf version
+if(SDL2_TTF_INCLUDE_DIR AND EXISTS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_TTF_INCLUDE_DIR}/SDL_ttf.h" SDL2_TTF_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MAJOR "${SDL2_TTF_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_TTF_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_MINOR "${SDL2_TTF_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_TTF_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_TTF_VERSION_PATCH "${SDL2_TTF_VERSION_PATCH_LINE}")
+  set(SDL2_TTF_VERSION_STRING ${SDL2_TTF_VERSION_MAJOR}.${SDL2_TTF_VERSION_MINOR}.${SDL2_TTF_VERSION_PATCH})
+  unset(SDL2_TTF_VERSION_MAJOR_LINE)
+  unset(SDL2_TTF_VERSION_MINOR_LINE)
+  unset(SDL2_TTF_VERSION_PATCH_LINE)
+  unset(SDL2_TTF_VERSION_MAJOR)
+  unset(SDL2_TTF_VERSION_MINOR)
+  unset(SDL2_TTF_VERSION_PATCH)
+endif()
+
+set(SDL2_TTF_LIBRARIES ${SDL2_TTF_LIBRARY})
+set(SDL2_TTF_INCLUDE_DIRS ${SDL2_TTF_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_ttf
+                                  REQUIRED_VARS SDL2_TTF_LIBRARIES SDL2_TTF_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_TTF_VERSION_STRING)
+
+
+mark_as_advanced(SDL2_TTF_PATH
+                 SDL2_TTF_NO_DEFAULT_PATH
+                 SDL2_TTF_LIBRARY
+                 SDL2_TTF_INCLUDE_DIR)
+
+
+if(SDL2_TTF_FOUND)
+
+  # SDL2_ttf::SDL2_ttf target
+  if(SDL2_TTF_LIBRARY AND NOT TARGET SDL2_ttf::SDL2_ttf)
+    add_library(SDL2_ttf::SDL2_ttf UNKNOWN IMPORTED)
+    set_target_properties(SDL2_ttf::SDL2_ttf PROPERTIES
+                          IMPORTED_LOCATION "${SDL2_TTF_LIBRARY}"
+                          INTERFACE_INCLUDE_DIRECTORIES "${SDL2_TTF_INCLUDE_DIR}"
+                          INTERFACE_LINK_LIBRARIES $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>)
+  endif()
+endif()

--- a/mk/cmake/modules/SDL2/README.md
+++ b/mk/cmake/modules/SDL2/README.md
@@ -1,0 +1,179 @@
+# SDL2 CMake modules
+
+This repository contains [CMake][] modules for finding and using the SDL2
+library as well as other related libraries:
+
+- [SDL2][]
+- [SDL2_image][]
+- [SDL2_ttf][]
+- [SDL2_net][]
+- [SDL2_mixer][]
+- [SDL2_gfx][]
+
+These modules are based on the SDL (1.2) modules, with the same names,
+distributed with the CMake project. The SDL2_gfx module is also based
+on the SDL_image module.
+
+## Details and Improvements
+
+The improvements made to these modules are as follows:
+
+**FindSDL2.cmake**
+
+- Adapt `FindSDL.cmake` to `SDL2` (`FindSDL2.cmake`).
+- Add cache variables for more flexibility:<br>
+    `SDL2_PATH`, `SDL2_NO_DEFAULT_PATH`
+- Mark `Threads` as a required dependency for non-OSX systems.
+- Modernize the `FindSDL2.cmake` module by creating specific targets:
+  - `SDL2::Core` : Library project should link to `SDL2::Core`
+  - `SDL2::Main` : Application project should link to `SDL2::Main`
+
+*For more details, please see the embedded documentation in `FindSDL2.cmake` file.*
+
+**FindSDL2_&lt;COMPONENT&gt;.cmake**
+
+- Adapt `FindSDL_<COMPONENT>.cmake` to `SDL2_<COMPONENT>` (`FindSDL2_<COMPONENT>.cmake`).
+- Add cache variables for more flexibility:<br>
+    `SDL2_<COMPONENT>_PATH`, `SDL2_<COMPONENT>_NO_DEFAULT_PATH`
+- Add `SDL2` as a required dependency.
+- Modernize the `FindSDL2_<COMPONENT>.cmake` modules by creating specific targets:<br>
+    `SDL2::Image`, `SDL2::TTF`, `SDL2::Net`, `SDL2::Mixer` and `SDL2::GFX`.
+
+*For more details, please see the embedded documentation in
+`FindSDL2_<COMPONENT>.cmake` file.*
+
+## Usage
+
+In order to use the SDL2 CMake modules, we have to clone this repository in a
+sud-directory `cmake/sdl2` in our project as follows:
+
+```sh
+cd <PROJECT_DIR>
+git clone https://gitlab.com/aminosbh/sdl2-cmake-modules.git cmake/sdl2
+rm -rf cmake/sdl2/.git
+```
+
+Or if we are using git for our project, we can add this repository as a
+submodule as follows:
+
+```sh
+cd <PROJECT_DIR>
+git submodule add https://gitlab.com/aminosbh/sdl2-cmake-modules.git cmake/sdl2
+git commit -m "Add SDL2 CMake modules"
+```
+
+Then we should specify the modules path in the main CMakeLists.txt file like
+the following:
+
+```cmake
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdl2)
+```
+
+Finally, we can use the SDL2 modules. There is two approaches that can be
+adopted: A legacy approach and a modern approach. Both of them are supported.
+
+### Modern CMake
+
+We can link to the SDL2:: targets like the following example:<br>
+*This example requires the SDL2, SDL2_image and the SDL2_gfx libraries*
+
+```cmake
+# Find SDL2, SDL2_image and SDL2_gfx libraries
+find_package(SDL2 REQUIRED)
+find_package(SDL2_image REQUIRED)
+find_package(SDL2_gfx REQUIRED)
+
+# Link SDL2::Main, SDL2::Image and SDL2::GFX to our project
+target_link_libraries(${PROJECT_NAME} SDL2::Main SDL2::Image SDL2::GFX)
+```
+
+*Use the appropriate packages for you project.*<br>
+*Please see above, for the whole list of packages*<br>
+*For more details, please see the embedded documentation in modules files*
+
+### Legacy CMake
+
+We can also specify manually the include directories and libraries to link to:
+
+```cmake
+# Find and link SDL2
+find_package(SDL2 REQUIRED)
+target_include_directories(${PROJECT_NAME} PRIVATE ${SDL2_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} ${SDL2_LIBRARIES})
+
+# Find and link SDL2_image
+find_package(SDL2_image REQUIRED)
+target_include_directories(${PROJECT_NAME} PRIVATE ${SDL2_IMAGE_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} ${SDL2_IMAGE_LIBRARIES})
+
+# Find and link SDL2_gfx
+find_package(SDL2_gfx REQUIRED)
+target_include_directories(${PROJECT_NAME} PRIVATE ${SDL2_GFX_INCLUDE_DIRS})
+target_link_libraries(${PROJECT_NAME} ${SDL2_GFX_LIBRARIES})
+
+```
+
+*For more details, please see the embedded documentation in modules files*
+
+## Special customization variables
+
+Each module have special customization cache variables that can be used to help
+the modules find the appropriate libraries:
+
+- `SDL2_PATH` and `SDL2_<COMPONENT>_PATH`:<br>
+  Can be specified to set the root search path for the `SDL2` and `SDL2_<COMPONENT>`
+- `SDL2_NO_DEFAULT_PATH` and `SDL2_<COMPONENT>_NO_DEFAULT_PATH`:<br>
+  Disable search `SDL2/SDL2_<COMPONENT>` library in default path:<br>
+    If `SDL2[_<COMPONENT>]_PATH` is set, defaults to ON<br>
+    Else defaults to OFF
+- `SDL2_INCLUDE_DIR` and `SDL2_<COMPONENT>_INCLUDE_DIR`:<br>
+  Set headers path. (Override)
+- `SDL2_LIBRARY` and `SDL2_<COMPONENT>_LIBRARY`:<br>
+  Set the library (.dll, .so, .a, etc) path. (Override)
+- `SDL2MAIN_LIBRAY`:<br>
+  Set the `SDL2main` library (.a) path. (Override)
+
+These variables could be used in case of Windows projects, and when the
+libraries are not localized in a standard pathes. They can be specified when
+executing the `cmake` command or when using the [CMake GUI][] (They are marked
+as advanced).
+
+**cmake command example:**
+
+```sh
+mkdir build
+cd build
+cmake .. -DSDL2_PATH="/path/to/sdl2"
+```
+
+**CMakeLists.txt example:**
+
+If we embed, for example, binaries of the SDL2_ttf in our project, we can
+specify the cache variables values just before calling the `find_package`
+command as follows:
+
+```cmake
+set(SDL2_TTF_PATH "/path/to/sdl2_ttf" CACHE BOOL "" FORCE)
+find_package(SDL2_ttf REQUIRED)
+```
+
+## License
+
+Maintainer: Amine B. Hassouna [@aminosbh](https://gitlab.com/aminosbh)
+
+The SDL2 CMake modules are based on the SDL (1.2) modules available with the
+CMake project which is distributed under the OSI-approved BSD 3-Clause License.
+
+The SDL2 CMake modules are also distributed under the OSI-approved BSD
+3-Clause License. See accompanying file [Copyright.txt](Copyright.txt).
+
+
+
+[CMake]: https://cmake.org
+[CMake GUI]: https://cmake.org/runningcmake
+[SDL2]: https://www.libsdl.org
+[SDL2_image]: https://www.libsdl.org/projects/SDL_image
+[SDL2_ttf]: https://www.libsdl.org/projects/SDL_ttf
+[SDL2_net]: https://www.libsdl.org/projects/SDL_net
+[SDL2_mixer]: https://www.libsdl.org/projects/SDL_mixer
+[SDL2_gfx]: http://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx


### PR DESCRIPTION
Adds CMake find modules for all SDL2 packages. These are adapted from https://github.com/aminosbh/sdl2-cmake-modules. This should help CMake to find the SDL2 packages in case the config files installed with the packages cannot be found.