### PR TITLE
Fix xml eisdir

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach(dataFile ${allDataFiles})
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "copying ${dataFile} to build directory"
   )
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${dataFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/${dataFile})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${dataFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR})
 endforeach()
 add_custom_target(allDataFiles.target DEPENDS ${allDataFiles})
 add_dependencies(lincity-ng allDataFiles.target)
@@ -91,7 +91,7 @@ foreach(infoFile ${infoFiles})
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "copying ${infoFile} to build directory"
   )
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${infoFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/${infoFile})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${infoFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR})
 endforeach()
 add_custom_target(infoFiles.target DEPENDS ${infoFiles})
 add_dependencies(lincity-ng infoFiles.target)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach(dataFile ${allDataFiles})
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "copying ${dataFile} to build directory"
   )
-  install(FILES ${dataFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/${dataFile})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${dataFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/${dataFile})
 endforeach()
 add_custom_target(allDataFiles.target DEPENDS ${allDataFiles})
 add_dependencies(lincity-ng allDataFiles.target)
@@ -91,7 +91,7 @@ foreach(infoFile ${infoFiles})
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "copying ${infoFile} to build directory"
   )
-  install(FILES ${infoFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/${infoFile})
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${infoFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/${infoFile})
 endforeach()
 add_custom_target(infoFiles.target DEPENDS ${infoFiles})
 add_dependencies(lincity-ng infoFiles.target)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -22,7 +22,8 @@ foreach(dataFile ${allDataFiles})
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "copying ${dataFile} to build directory"
   )
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${dataFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR})
+  cmake_path(GET dataFile PARENT_PATH dataFileDst)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${dataFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/${dataFileDst})
 endforeach()
 add_custom_target(allDataFiles.target DEPENDS ${allDataFiles})
 add_dependencies(lincity-ng allDataFiles.target)
@@ -91,7 +92,8 @@ foreach(infoFile ${infoFiles})
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "copying ${infoFile} to build directory"
   )
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${infoFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR})
+  cmake_path(GET infoFile PARENT_PATH infoFileDst)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${infoFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/${infoFileDst})
 endforeach()
 add_custom_target(infoFiles.target DEPENDS ${infoFiles})
 add_dependencies(lincity-ng infoFiles.target)


### PR DESCRIPTION
Specifies the correct install DESTINATION for some files. The DESTINATION should be the directory to install the files to -- not the installed filename.

Fixes #100 .