### PR TITLE
Add 'git' to the build deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN apt-get install -y \
   libxslt1.1 \
   libxslt1-dev \
   xsltproc \
-  gettext
+  gettext \
+  git
 
 RUN mkdir -p /home/lincity-ng
 # COPY . /home/lincity-ng/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ apt-get install libsdl2-2.0-0 libsdl2-gfx-1.0-0 libsdl2-image-2.0-0 libsdl2-mixe
 
   https://gcc.gnu.org/
 
+* git
+
+  https://git-scm.com/
+
 * CMake 3.21 or later
 
   https://cmake.org/
@@ -76,7 +80,7 @@ apt-get install libsdl2-2.0-0 libsdl2-gfx-1.0-0 libsdl2-image-2.0-0 libsdl2-mixe
 
 On Ubuntu, install all build dependencies by running
 ```
-apt-get install build-essential cmake libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libphysfs-dev zlib1g-dev libxml++2.6-dev libxslt1.1 libxslt1-dev xsltproc gettext
+apt-get install build-essential cmake libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-ttf-dev libphysfs-dev zlib1g-dev libxml++2.6-dev libxslt1.1 libxslt1-dev xsltproc gettext git
 ```
 
 ### Building


### PR DESCRIPTION
Adds git to the list of build dependencies. This is required in order to put the current git hash in the version number and is important for the Ubuntu package.