### PR TITLE
Improve waste fire handling so they are not a separate construction

### DIFF
--- a/data/gui/CMakeLists.txt
+++ b/data/gui/CMakeLists.txt
@@ -24,15 +24,15 @@ set(guiSourceFiles
 
 foreach(guiSourceFile ${guiSourceFiles})
   add_custom_command(
-    OUTPUT ${guiSourceFile}
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${guiSourceFile}
     COMMAND LibXslt::xsltproc -o ${CMAKE_CURRENT_BINARY_DIR}/${guiSourceFile} ${guiSourceFile}
-    DEPENDS ${guiSourceFile}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${guiSourceFile}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Convert XML GUI ${guiSourceFile}"
   )
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${guiSourceFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/gui/)
 endforeach()
 
 add_custom_target(guiXml DEPENDS ${guiSourceFiles})
 add_dependencies(lincity-ng guiXml)
-
-install(FILES ${guiSourceFiles} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/gui/)

--- a/data/gui/dialogs/CMakeLists.txt
+++ b/data/gui/dialogs/CMakeLists.txt
@@ -49,15 +49,15 @@ set(guiDialogSourceFiles
 
 foreach(guiDialogSourceFile ${guiDialogSourceFiles})
   add_custom_command(
-    OUTPUT ${guiDialogSourceFile}
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${guiDialogSourceFile}
     COMMAND LibXslt::xsltproc -o ${CMAKE_CURRENT_BINARY_DIR}/${guiDialogSourceFile} ${guiDialogSourceFile}
-    DEPENDS ${guiDialogSourceFile}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${guiDialogSourceFile}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Convert XML GUI dialogs/${guiDialogSourceFile}"
   )
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${guiDialogSourceFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/gui/dialogs/)
 endforeach()
 
 add_custom_target(guiDialogXml DEPENDS ${guiDialogSourceFiles})
 add_dependencies(lincity-ng guiDialogXml)
-
-install(FILES ${guiDialogSourceFiles} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/gui/dialogs/)

--- a/src/lincity/modules/market.cpp
+++ b/src/lincity/modules/market.cpp
@@ -174,24 +174,18 @@ void Market::animate() {
   }
   soundGroup = frameIt->resourceGroup;
 
-  if(start_burning_waste) {
+  if(start_burning_waste) { // start fire
     start_burning_waste = false;
     anim = real_time + ANIM_THRESHOLD(6 * WASTE_BURN_TIME);
-    if(!world(x+1,y+1)->construction) {
-      Construction *fire = fireConstructionGroup.createConstruction(x+1, y+1);
-      //waste burning never spreads
-      (dynamic_cast<Fire*>(fire))->flags |= FLAG_IS_GHOST;
-      world(x+1,y+1)->construction = fire;
-      world(x+1,y+1)->reportingConstruction = fire;
-      ::constructionCount.add_construction(fire);
-    }
   }
-  else if(real_time >= anim && world(x+1,y+1)->construction) {
-      ::constructionCount.remove_construction(world(x+1,y+1)->construction);
-      world(x+1,y+1)->killframe(world(x+1,y+1)->construction->frameIt);
-      delete world(x+1,y+1)->construction;
-      world(x+1,y+1)->construction = NULL;
-      world(x+1,y+1)->reportingConstruction = this;
+  if(real_time >= anim) { // stop fire
+    waste_fire_frit->frame = -1;
+  }
+  else if(real_time >= waste_fire_anim) { // continue fire
+    waste_fire_anim = real_time + ANIM_THRESHOLD(FIRE_ANIMATION_SPEED);
+    int num_frames = waste_fire_frit->resourceGroup->graphicsInfoVector.size();
+    if(++waste_fire_frit->frame >= num_frames)
+      waste_fire_frit->frame = 0;
   }
 }
 

--- a/src/lincity/modules/market.h
+++ b/src/lincity/modules/market.h
@@ -79,6 +79,11 @@ public:
     {
         this->constructionGroup = cstgrp;
         init_resources();
+        waste_fire_frit = world(x, y)->createframe();
+        waste_fire_frit->resourceGroup = ResourceGroup::resMap["Fire"];
+        waste_fire_frit->move_x = 0;
+        waste_fire_frit->move_y = 0;
+        waste_fire_frit->frame = -1;
         //local copy of commodityRuCount
         commodityRuleCount = constructionGroup->commodityRuleCount;
         setCommodityRulesSaved(&commodityRuleCount);
@@ -89,6 +94,7 @@ public:
         this->working_days = 0;
         this->market_ratio = 0;
         this->start_burning_waste = false;
+        this->waste_fire_anim = 0;
         //set the Searchrange of this Market
         int tmp;
         int lenm1 = world.len()-1;
@@ -105,6 +111,10 @@ public:
         commodityMaxCons[STUFF_JOBS] = 100 * JOBS_MARKET_FULL;
         commodityMaxCons[STUFF_WASTE] = 100 * ((7 * MAX_WASTE_IN_MARKET) / 10);
     }
+    virtual ~Market() {
+        world(x,y)->killframe(waste_fire_frit);
+    }
+
     virtual void update() override;
     virtual void report() override;
     virtual void animate() override;
@@ -118,6 +128,8 @@ public:
     int anim;
     int market_ratio;
     bool start_burning_waste;
+    std::list<ExtraFrame>::iterator waste_fire_frit;
+    int waste_fire_anim;
 };
 
 /** @file lincity/modules/market.h */

--- a/src/lincity/modules/shanty.cpp
+++ b/src/lincity/modules/shanty.cpp
@@ -152,32 +152,32 @@ void Shanty::update()
     if (commodityCount[STUFF_STEEL] >= SHANTY_GET_STEEL)
     {   consumeStuff(STUFF_STEEL, SHANTY_GET_STEEL);}
     produceStuff(STUFF_WASTE, SHANTY_PUT_WASTE);
-    if (commodityCount[STUFF_WASTE] >= MAX_WASTE_AT_SHANTY && !world(x+1,y+1)->construction)
+    if (commodityCount[STUFF_WASTE] >= MAX_WASTE_AT_SHANTY)
     {
-        anim = real_time + 3 * WASTE_BURN_TIME;
         world(x+1,y+1)->pollution += commodityCount[STUFF_WASTE];
         levelStuff(STUFF_WASTE, 0);
-        if(!world(x+1,y+1)->construction)
-        {
-            Construction *fire = fireConstructionGroup.createConstruction(x+1, y+1);
-            world(x+1,y+1)->construction = fire;
-            world(x+1,y+1)->reportingConstruction = fire;
-            dynamic_cast<Fire*>(fire)->flags |= FLAG_IS_GHOST;
-            ::constructionCount.add_construction(fire);
-        }
-    }
-    else if ( real_time > anim && world(x+1,y+1)->construction)
-    {
-        ::constructionCount.remove_construction(world(x+1,y+1)->construction);
-        world(x+1,y+1)->killframe(world(x+1,y+1)->construction->frameIt);
-        delete world(x+1,y+1)->construction;
-        world(x+1,y+1)->construction = NULL;
-        world(x+1,y+1)->reportingConstruction = this;
+        start_burning_waste = true;
     }
 
     if(total_time % 100 == 99) {
         reset_prod_counters();
     }
+}
+
+void Shanty::animate() {
+  if(start_burning_waste) { // start fire
+    start_burning_waste = false;
+    anim = real_time + ANIM_THRESHOLD(3 * WASTE_BURN_TIME);
+  }
+  if(real_time >= anim) { // stop fire
+    waste_fire_frit->frame = -1;
+  }
+  else if(real_time >= waste_fire_anim) { // continue fire
+    waste_fire_anim = real_time + ANIM_THRESHOLD(FIRE_ANIMATION_SPEED);
+    int num_frames = waste_fire_frit->resourceGroup->graphicsInfoVector.size();
+    if(++waste_fire_frit->frame >= num_frames)
+      waste_fire_frit->frame = 0;
+  }
 }
 
 void Shanty::report()

--- a/src/lincity/modules/shanty.h
+++ b/src/lincity/modules/shanty.h
@@ -85,9 +85,16 @@ public:
     {
         this->constructionGroup = cstgrp;
         init_resources();
+        waste_fire_frit = world(x, y)->createframe();
+        waste_fire_frit->resourceGroup = ResourceGroup::resMap["Fire"];
+        waste_fire_frit->move_x = 0;
+        waste_fire_frit->move_y = 0;
+        waste_fire_frit->frame = -1;
         initialize_commodities();
         this->flags |= FLAG_NEVER_EVACUATE;
         this->anim = 0;
+        this->start_burning_waste = false;
+        this->waste_fire_anim = 0;
 
         commodityMaxProd[STUFF_WASTE] = 100 *
           (SHANTY_PUT_WASTE * 2 + SHANTY_GET_GOODS / 3);
@@ -100,10 +107,18 @@ public:
         commodityMaxCons[STUFF_WASTE] = 100 *
           (MAX_WASTE_AT_SHANTY /*+ SHANTY_PUT_WASTE*2 + SHANTY_GET_GOODS/3*/);
     }
-    virtual ~Shanty() { }
-    virtual void update();
-    virtual void report();
+    virtual ~Shanty() {
+        world(x,y)->killframe(waste_fire_frit);
+    }
+
+    virtual void update() override;
+    virtual void report() override;
+    virtual void animate() override;
+
     int anim;
+    bool start_burning_waste;
+    std::list<ExtraFrame>::iterator waste_fire_frit;
+    int waste_fire_anim;
 };
 
 

--- a/src/lincity/modules/track_road_rail.h
+++ b/src/lincity/modules/track_road_rail.h
@@ -100,7 +100,8 @@ public:
     {
         unsigned short group = cstgrp->group;
         this->anim = 0;
-        this->burning_waste = false;
+        this->start_burning_waste = false;
+        this->waste_fire_anim = 0;
         // register the construction as transport tile
         // disable evacuation
         //transparency is set and updated in connect_transport
@@ -180,6 +181,11 @@ public:
                 assert(false);
         }
         init_resources();
+        waste_fire_frit = world(x, y)->createframe();
+        waste_fire_frit->resourceGroup = ResourceGroup::resMap["Fire"];
+        waste_fire_frit->move_x = 0;
+        waste_fire_frit->move_y = 0;
+        waste_fire_frit->frame = -1;
 
         initialize_commodities();
         this->trafficCount = this->commodityCount;
@@ -232,6 +238,8 @@ public:
                 std::cout << "counting error in Transport IDs" << std::endl;
             break;
         }
+
+        world(x,y)->killframe(waste_fire_frit);
     }
     Counted<Track> *countedTrack;
     Counted<Road> *countedRoad;
@@ -247,6 +255,7 @@ public:
     void list_traffic( int* i);
     int subgroupID;
     int anim;
-    bool burning_waste;
-    bool burning_waste_anim;
+    bool start_burning_waste;
+    std::list<ExtraFrame>::iterator waste_fire_frit;
+    int waste_fire_anim;
 };


### PR DESCRIPTION
Previously, waste burning at markets, shanties, and track/road/rail would create a ghost fire construction on top of the existing construction to create a fire animation. This caused various issues including #123 because some parts of the code assumed only one construction per map location.

This PR removes these ghost fire constructions and instead uses `ExtraFrame`s for waste fire animation similar to how smoke is created for coal power and heavy industry. This PR does not remove the notion of ghost fires even though this "feature" is problematic and no longer used. and probably should be removed just to keep the code tidy.

Fixes #123