### PR TITLE
Fix GUI XML install

### DIFF
--- a/data/gui/CMakeLists.txt
+++ b/data/gui/CMakeLists.txt
@@ -24,15 +24,15 @@ set(guiSourceFiles
 
 foreach(guiSourceFile ${guiSourceFiles})
   add_custom_command(
-    OUTPUT ${guiSourceFile}
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${guiSourceFile}
     COMMAND LibXslt::xsltproc -o ${CMAKE_CURRENT_BINARY_DIR}/${guiSourceFile} ${guiSourceFile}
-    DEPENDS ${guiSourceFile}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${guiSourceFile}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Convert XML GUI ${guiSourceFile}"
   )
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${guiSourceFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/gui/)
 endforeach()
 
 add_custom_target(guiXml DEPENDS ${guiSourceFiles})
 add_dependencies(lincity-ng guiXml)
-
-install(FILES ${guiSourceFiles} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/gui/)

--- a/data/gui/dialogs/CMakeLists.txt
+++ b/data/gui/dialogs/CMakeLists.txt
@@ -49,15 +49,15 @@ set(guiDialogSourceFiles
 
 foreach(guiDialogSourceFile ${guiDialogSourceFiles})
   add_custom_command(
-    OUTPUT ${guiDialogSourceFile}
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${guiDialogSourceFile}
     COMMAND LibXslt::xsltproc -o ${CMAKE_CURRENT_BINARY_DIR}/${guiDialogSourceFile} ${guiDialogSourceFile}
-    DEPENDS ${guiDialogSourceFile}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${guiDialogSourceFile}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Convert XML GUI dialogs/${guiDialogSourceFile}"
   )
+
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${guiDialogSourceFile} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/gui/dialogs/)
 endforeach()
 
 add_custom_target(guiDialogXml DEPENDS ${guiDialogSourceFiles})
 add_dependencies(lincity-ng guiDialogXml)
-
-install(FILES ${guiDialogSourceFiles} DESTINATION ${CMAKE_INSTALL_APPDATADIR}/gui/dialogs/)


### PR DESCRIPTION
Fixes the CMake `install` directives for GUI XML so that the xslt-processed XML is installed. Previously, the source XML was installed.

fixes #122, fixes #125 