### PR TITLE
fix compile errors for older systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,18 @@
+## Unreleased
+
+###### Internal
+- Fixed a compile-time error in src/gui/event.cpp when building with
+  SDL <= 2.26.0.
+- Fixed a compile-time error in src/lincity/xmlloadsave.cpp when building with
+  older g++ version.
+- Fixed parsing boolean from XML save file.
+
+
 ## LinCity NG 2.11.0
 
 date: 2024-06-24 <br/>
 tag: lincity-ng-2.11.0 <br/>
+git: afaede3d
 
 ###### Gameplay
 - Nerfed ports by randomly disabling import/export.
@@ -42,6 +53,7 @@ tag: lincity-ng-2.11.0 <br/>
 ###### Known Issues
 - Some translations may be outdated since renaming commodities.
 - Production/Consumption formulas do not exist in translated help pages.
+- Requires SDL >= 2.26.0
 
 
 ## LinCity NG 2.10.2

--- a/src/gui/Event.cpp
+++ b/src/gui/Event.cpp
@@ -54,7 +54,9 @@ Event::Event(SDL_Event& event)
             #if SDL_VERSION_ATLEAST(2,26,0)
             mousepos = Vector2(event.wheel.mouseX, event.wheel.mouseY);
             #else
-            SDL_GetMouseState(&mousepos.x, &mousepos.y);
+            int x, y;
+            SDL_GetMouseState(&x, &y);
+            mousepos = Vector2(x, y);
             #endif
             break;
         case SDL_WINDOWEVENT:

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -18,7 +18,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 #include "GameView.hpp"
 
-#include <SDL.h>                           // for SDL_BUTTON_LEFT, SDL_SetCu...
+#include <SDL.h>                           // for SDL_BUTTON_LEFT, SDL_BUTTO...
 #include <SDL_image.h>                     // for IMG_Load_RW
 #include <assert.h>                        // for assert
 #include <physfs.h>                        // for PHYSFS_exists
@@ -31,6 +31,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <list>                            // for _List_iterator, list, oper...
 #include <map>                             // for _Rb_tree_iterator, map
 #include <sstream>                         // for basic_stringstream, basic_...
+#include <stdexcept>                       // for runtime_error
 #include <utility>                         // for pair
 #include <vector>                          // for vector
 

--- a/src/lincity-ng/ScreenInterface.cpp
+++ b/src/lincity-ng/ScreenInterface.cpp
@@ -19,12 +19,13 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "ScreenInterface.hpp"
 
 #include <errno.h>                           // for errno
+#include <stdio.h>                           // for snprintf
 #include <stdlib.h>                          // for abs, malloc
 #include <exception>                         // for exception
 #include <iomanip>                           // for operator<<, setfill, setw
 #include <iostream>                          // for basic_ostream, operator<<
 #include <sstream>                           // for basic_ostringstream
-#include <string>                            // for char_traits, basic_string
+#include <string>                            // for basic_string, char_traits
 
 #include "ButtonPanel.hpp"                   // for getButtonPanel, ButtonPanel
 #include "Config.hpp"                        // for getConfig, Config

--- a/src/lincity/init_game.cpp
+++ b/src/lincity/init_game.cpp
@@ -16,6 +16,7 @@
 //#define DEBUG_EXPERIMENTAL
 
 #include <algorithm>                       // for max
+#include <array>                           // for array
 #include <cmath>                           // for pow, exp
 #include <cstdlib>                         // for rand, NULL, size_t, srand
 #include <deque>                           // for deque
@@ -27,6 +28,7 @@
 #include "ConstructionManager.h"           // for ConstructionManager
 #include "Vehicles.h"                      // for Vehicle
 #include "all_buildings.h"                 // for COAL_RESERVE_SIZE, COAL_TA...
+#include "commodities.hpp"                 // for Commodity, CommodityRule
 #include "engglobs.h"                      // for world, global_mountainity
 #include "engine.h"                        // for desert_water_frontiers
 #include "groups.h"                        // for GROUP_BARE, GROUP_TREE

--- a/src/lincity/simulate.cpp
+++ b/src/lincity/simulate.cpp
@@ -4,7 +4,8 @@
  * Lincity is copyright (c) I J Peters 1995-1997, (c) Greg Sharp 1997-2001.
  * ---------------------------------------------------------------------- */
 
-#include <stdlib.h>                        // for abs, rand
+#include <stdlib.h>                        // for rand, abs
+#include <array>                           // for array
 #include <iterator>                        // for advance
 #include <list>                            // for list, _List_iterator, oper...
 //#include "common.h"
@@ -20,20 +21,21 @@
 #include "ConstructionManager.h"           // for ConstructionManager
 #include "Vehicles.h"                      // for Vehicle
 #include "all_buildings.h"                 // for DAYS_BETWEEN_COVER, DAYS_P...
+#include "commodities.hpp"                 // for CommodityRule, Commodity
 #include "engglobs.h"                      // for tech_level, total_money
 #include "engine.h"                        // for do_random_fire, scan_pollu...
 #include "groups.h"                        // for GROUP_FIRE, GROUP_MONUMENT
 #include "gui_interface/pbar_interface.h"  // for update_pbars_monthly
 #include "lin-city.h"                      // for MAX_TECH_LEVEL, TECH_LEVEL...
 #include "lintypes.h"                      // for Construction, NUMOF_DAYS_I...
-#include "modules/all_modules.h"           // for DAYS_BETWEEN_FIRES, DAYS_B...
+#include "modules/all_modules.h"           // for IMPORT_EXPORT_DISABLE_PERIOD
 #include "modules/modules_interfaces.h"    // for update_shanty
 #include "simulate.h"
 //#include "power.h"
 #include "stats.h"                         // for export_tax, goods_tax, ly_...
 #include "sustainable.h"                   // for SUST_MIN_TECH_LEVEL, SUST_...
 #include "tinygettext/gettext.hpp"         // for _
-#include "world.h"                         // for World
+#include "world.h"                         // for World, MapTile
 
 
 /* extern resources */

--- a/src/lincity/xmlloadsave.cpp
+++ b/src/lincity/xmlloadsave.cpp
@@ -4,22 +4,24 @@
 #include <stdio.h>                         // for sscanf
 #include <string.h>                        // for strcpy
 #include <algorithm>                       // for max
+#include <array>                           // for array
 #include <iostream>                        // for cout
 #include <set>                             // for set
 #include <utility>                         // for pair
 
 #include "ConstructionCount.h"             // for ConstructionCount
+#include "commodities.hpp"                 // for Commodity, CommodityRule
 #include "engglobs.h"                      // for world, binary_mode, constr...
 #include "groups.h"                        // for GROUP_DESERT
 #include "gui_interface/pbar_interface.h"  // for pbar_st, pbars, PBAR_DATA_...
 #include "gui_interface/shared_globals.h"  // for monthgraph_size, cheat_flag
 #include "init_game.h"                     // for create_new_city
 #include "lin-city.h"                      // for VOLATILE_FLAGS, FLAG_ALTERED
-#include "lintypes.h"                      // for MapTile, Ground, Construction
+#include "lintypes.h"                      // for Construction, Construction...
 #include "loadsave.h"                      // for given_scene
+#include "modules/port.h"                  // for PortConstructionGroup, por...
 #include "stats.h"                         // for ly_cricket_cost, ly_deaths...
-#include "world.h"                         // for World
-#include "modules/port.h"
+#include "world.h"                         // for MapTile, World, Ground
 
 std::map <std::string, XMLTemplate*> xml_template_libary;
 std::map <unsigned short, XMLTemplate*> bin_template_libary;

--- a/src/lincity/xmlloadsave.cpp
+++ b/src/lincity/xmlloadsave.cpp
@@ -888,10 +888,16 @@ void XMLloadsave::loadGlobals()
             else goto more_globals; goto found_global; more_globals:
 
             for(Commodity c = STUFF_INIT; c < STUFF_COUNT; c++) {
+              bool *ixenable = NULL;
               const char * const &cname = commodityNames[c];
-              if     (xml_tag == std::string("import_") + cname + "_enable") sscanf(xml_val.c_str(),"%d",&portConstructionGroup.tradeRule[c].take);
-              else if(xml_tag == std::string("export_") + cname + "_enable") sscanf(xml_val.c_str(),"%d",&portConstructionGroup.tradeRule[c].give);
-              else continue; goto found_global;
+              if     (xml_tag == std::string("import_") + cname + "_enable") ixenable = &portConstructionGroup.tradeRule[c].take;
+              else if(xml_tag == std::string("export_") + cname + "_enable") ixenable = &portConstructionGroup.tradeRule[c].give;
+              else continue;
+
+              int tmp;
+              sscanf(xml_val.c_str(),"%d",&tmp);
+              *ixenable = tmp;
+              goto found_global;
             }
 
             std::cout << "Unknown XML entry " << line

--- a/src/lincity/xmlloadsave.cpp
+++ b/src/lincity/xmlloadsave.cpp
@@ -898,7 +898,7 @@ void XMLloadsave::loadGlobals()
               << " while reading <GlobalVariables>" << std::endl;
             globalCount--;
 
-            found_global:
+            found_global: ;
         }
         else if (r == 1) //an opening xml tag
         {


### PR DESCRIPTION
Fixes some compile-time errors on systems using older version of gcc and/or older version of sdl.

- Fixes #144.
- Fixes #145.
- Fixes bad parsing of bool in XML save file.
- Fixes up some includes.