### PR TITLE
modify how existing vehicles are detected on a track/road/rail tile

### DIFF
--- a/src/lincity/lintypes.cpp
+++ b/src/lincity/lintypes.cpp
@@ -981,10 +981,13 @@ void Construction::trade()
                 {
                     case STUFF_LABOR :
                         if((rand()%COMMUTER_TRAFFIC_RATE) < (yield+1)/2
-                        && world(x,y)->framesptr //useful check in case the road is bulldozed
-                        &&  world(x,y)->framesptr->size() < 2) //only generate cars on emtpy streets
-                        {   new Vehicle(x, y, VEHICLE_BLUECAR,
-                                        (flow > 0)? VEHICLE_STRATEGY_MAXIMIZE : VEHICLE_STRATEGY_MINIMIZE);}
+                          && transport->canPlaceVehicle()
+                        ) {
+                          new Vehicle(x, y, VEHICLE_BLUECAR, (flow > 0)
+                            ? VEHICLE_STRATEGY_MAXIMIZE
+                            : VEHICLE_STRATEGY_MINIMIZE
+                          );
+                        }
                         break;
                     default:
                         break;

--- a/src/lincity/modules/track_road_rail.cpp
+++ b/src/lincity/modules/track_road_rail.cpp
@@ -239,5 +239,14 @@ void Transport::playSound()
     }
 }
 
+bool Transport::canPlaceVehicle() {
+  if(!world(x, y)->framesptr)
+    return false;
+  for(ExtraFrame& exfr : *world(x, y)->framesptr)
+    if(exfr.resourceGroup->is_vehicle)
+      return false;
+  return true;
+}
+
 
 /** @file lincity/modules/track_road_rail_powerline.cpp */

--- a/src/lincity/modules/track_road_rail.h
+++ b/src/lincity/modules/track_road_rail.h
@@ -257,6 +257,7 @@ public:
     virtual void report() override;
     virtual void animate() override;
     virtual void playSound(); //override random sound
+    virtual bool canPlaceVehicle();
     std::array<int, STUFF_COUNT> trafficCount;
     void list_traffic( int* i);
     int subgroupID;


### PR DESCRIPTION
Before placing a new vehicle, `Construction::trade` makes sure there is not already a vehicle on that tile. Previously, this was done by counting the number of extra-frames on the map tile -- if there was more than one frame, then it was assumed that the second one was a vehicle. But in #126, we added a fire extra-frame to every transport tile for the waste burning animation, and this messed up the vehicle detection. So this PR changes the vehicle detection by looping through the extra-frames and checking whether `is_vehicle` is true for any of them.

- Fixes #155