### PR TITLE
avoid installing unneeded image source files

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -4,7 +4,8 @@ add_subdirectory(gui)
 file(GLOB_RECURSE allDataFiles RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS
   fonts/*
   help/*
-  images/*
+  images/*.png
+  images/*.xml
   locale/*
   music/*
   opening/*.scn


### PR DESCRIPTION
Only install .png files and 1 .xml file.

all the .svg under data/images and the following files are now no longer installed:
data/images/tiles/README.txt
data/images/tiles/list
data/images/tiles/extend.sh
data/images/gui/buttonpanel/waterwell.xcf

Fixes #166.