### PR TITLE
fix broken path after edcb1a5a442e0d232bf377148339811f1af0cd5b

### DIFF
--- a/contrib/render/croprender.sh
+++ b/contrib/render/croprender.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for i in ../data/images/tiles.render/*; do
+for i in ../../data/images/tiles.render/*; do
     ./autocrop "$i" "$i"
 done
 

--- a/contrib/render/render.sh
+++ b/contrib/render/render.sh
@@ -2,14 +2,21 @@
 
 set -e -x
 
-mkdir -p tmp/
-mkdir -p ../data/images/tiles.render/
+if [ "$(dirname $0)" != "." ]; then
+	echo error: `basename $0` must be run from its own directory with ./`basename $0`
+	exit
+fi
 
-for i in ../data/models/*.blend; do
-    blender -b "$i"  -P render.py
+mkdir -p tmp
+cd ../../data/images
+mkdir -p tiles.render
+cd -
+
+for i in ../../data/models/*.blend; do
+    blender -b "$i" -P render.py
     blender -b tmp/tmp.blend -a
     b=`basename $i`
-    cp -v tmp/0001 "../data/images/tiles.render/${b%%.blend}.png"
+    cp -v tmp/0001 "../../data/images/tiles.render/${b%%.blend}.png"
 done
 
 # EOF #


### PR DESCRIPTION
https://github.com/lincity-ng/lincity-ng/commit/edcb1a5a442e0d232bf377148339811f1af0cd5b moved the croprender.sh and render.sh in a different directory, the relative paths are now broken. Fix them, also check that the script is run from its own dir, and change to proper images dir before creating tiles.render dir with -p, to avoid creating a full dir tree if it should be moved again.

Note: partially tested since I cannot run blender.