### PR TITLE
Fix farm tech bonus initilization

### DIFF
--- a/src/lincity/modules/coal_power.h
+++ b/src/lincity/modules/coal_power.h
@@ -117,7 +117,7 @@ public:
         RegisteredConstruction::initialize();
 
         this->hivolt_output = (int)(POWERS_COAL_OUTPUT +
-          (((double)tech_level * POWERS_COAL_OUTPUT) / MAX_TECH_LEVEL));
+          (((double)tech * POWERS_COAL_OUTPUT) / MAX_TECH_LEVEL));
         commodityMaxProd[STUFF_HIVOLT] = 100 * hivolt_output;
     }
 

--- a/src/lincity/modules/organic_farm.h
+++ b/src/lincity/modules/organic_farm.h
@@ -116,7 +116,8 @@ public:
     virtual void initialize() override {
         RegisteredConstruction::initialize();
 
-        this->tech_bonus = int( ((long long int)tech_level * ORGANIC_FARM_FOOD_OUTPUT) / MAX_TECH_LEVEL );
+        this->tech_bonus = (int)((long long int)this->tech
+          * ORGANIC_FARM_FOOD_OUTPUT / MAX_TECH_LEVEL);
 
         commodityMaxProd[STUFF_FOOD] = 100 *
           (ORGANIC_FARM_FOOD_OUTPUT + tech_bonus);

--- a/src/lincity/modules/solar_power.h
+++ b/src/lincity/modules/solar_power.h
@@ -66,7 +66,7 @@ public:
         RegisteredConstruction::initialize();
 
         this->hivolt_output = (int)(POWERS_SOLAR_OUTPUT +
-          (((double)tech_level * POWERS_SOLAR_OUTPUT) / MAX_TECH_LEVEL));
+          (((double)tech * POWERS_SOLAR_OUTPUT) / MAX_TECH_LEVEL));
 
         commodityMaxProd[STUFF_HIVOLT] = 100 * hivolt_output;
     }

--- a/src/lincity/modules/windmill.h
+++ b/src/lincity/modules/windmill.h
@@ -72,7 +72,7 @@ public:
       RegisteredConstruction::initialize();
 
       this->lovolt_output = (int)(WINDMILL_LOVOLT +
-        (((double)tech_level * WINDMILL_LOVOLT) / MAX_TECH_LEVEL));
+        (((double)tech * WINDMILL_LOVOLT) / MAX_TECH_LEVEL));
 
       commodityMaxProd[STUFF_LOVOLT] = 100 * lovolt_output;
     }

--- a/src/lincity/modules/windpower.h
+++ b/src/lincity/modules/windpower.h
@@ -75,7 +75,7 @@ public:
         RegisteredConstruction::initialize();
 
         this->hivolt_output = (int)(WIND_POWER_HIVOLT +
-          (((double)tech_level * WIND_POWER_HIVOLT) / MAX_TECH_LEVEL));
+          (((double)tech * WIND_POWER_HIVOLT) / MAX_TECH_LEVEL));
 
         commodityMaxProd[STUFF_HIVOLT] = 100 * hivolt_output;
     }


### PR DESCRIPTION
Fixes initialization of farm tech_bonus so it is based on original tech level instead of current tech.

Fixes #177