### PR TITLE
Fix heap overflow while reading save file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,24 @@
 ## Unreleased [SECURITY]
 
+###### Gameplay
+- Fixed sustainability not resetting when dumping on a tip.
+- Fixed tech-based output for farms and power stations.
+
+###### User Interface
+- Fixed cars not spawning on track/road/rail.
+
 ###### Internal
 - [SECURITY] Fixed a heap overflow in game loading.
+- Fixed an error raised by CPack for missing README.md file.
+- Removed unneeded image source files from install.
+
+###### Documentation
+- Fixed the tip icon in help pages.
+- Added Italian translation for .desktop file.
+- Fixed several inconsistencies in translated help pages.
+- Added a script for detecting inconsistencies in translated help pages.
+- Fixed a typo in the rocket help page.
+
 
 ## LinCity-NG 2.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-## Unreleased
+## Unreleased [SECURITY]
 
+###### Internal
+- [SECURITY] Fixed a heap overflow in game loading.
 
 ## LinCity-NG 2.11.1
 

--- a/src/lincity/xmlloadsave.cpp
+++ b/src/lincity/xmlloadsave.cpp
@@ -1083,10 +1083,8 @@ void XMLloadsave::readArray(int ary[], int max_len, int len)
                 pos = xml_val.find("\t");
                 val = xml_val.substr(0, pos);
                 sscanf(val.c_str(),"%d",&ary[i++]);
-                if ((i > max_len) || (i > len))
-                {
-                    return;
-                }
+                if ((i >= max_len) || (i >= len))
+                    break;
                 xml_val.erase(0, pos);
                 xml_val.erase(0,1);
             }


### PR DESCRIPTION
Fixes a potential heap overflow in `XMLloadsave::readArray`. Without this patch, loading an attacker-controlled save file could allow the attacker to write a single byte to memory that they aren't supposed to have access to. The severity of this vulnerability is unknown, e.g. whether it could allow remote code execution.