### PR TITLE
move Dockerfile and package-ubuntu.sh to contrib

### DIFF
--- a/contrib/build/Dockerfile
+++ b/contrib/build/Dockerfile
@@ -32,4 +32,4 @@ RUN mkdir -p /home/lincity-ng
 # COPY . /home/lincity-ng/
 WORKDIR /home/lincity-ng
 
-CMD bash -c "cmake -B build/ubuntu && cmake --build build/ubuntu --parallel -t package -t package_source"
+CMD bash -c "cmake -B build/ubuntu && cmake --build build/ubuntu --parallel -t package"

--- a/contrib/build/package-ubuntu.sh
+++ b/contrib/build/package-ubuntu.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-docker build . -t lincity-ng-build-env --network=host && \
+docker build -f contrib/build/Dockerfile . -t lincity-ng-build-env --network=host && \
 docker run -v .:/home/lincity-ng -u $(id -u):$(id -g) lincity-ng-build-env


### PR DESCRIPTION
I haven't used Dockerfile or package-ubuntu.sh in a while, so I moved them to the contrib directory to tidy up the project root.