### PR TITLE
deprecate seed-compression saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 - Changed rocket icon.
 
 ###### Internal
-- Deprecated binary save format.
-- Deprecated old save format.
-- Converted starting scenarios to new save format.
+- Deprecated binary load/save format.
+- Deprecated old load/save format.
+- Deprecated seed-compression load/save mode.
+- Converted starting scenarios to current save format.
 - Fixed simulation tick on load when paused.
 - Removed many unused files from install.
 

--- a/data/gui/options.xml
+++ b/data/gui/options.xml
@@ -178,7 +178,7 @@
         </cell> -->
 
          <!-- Use Binary Saveganes -->
-        <cell row="9" col="2" valign="center" halign="left">
+        <!-- <cell row="9" col="2" valign="center" halign="left">
             <Paragraph style="listtitle" translatable="yes">Seed Saving</Paragraph>
         </cell>
         <cell row="9" col="3">
@@ -186,7 +186,7 @@
                 <image src="images/gui/checkbox/checkbox.png"/>
                 <image-checked src="images/gui/checkbox/checkbox_checked.png"/>
             </CheckButton>
-        </cell>
+        </cell> -->
 
         <!-- BackButton -->
         <cell row="10" col="2" colspan="2" halign="right">

--- a/src/lincity-ng/Config.cpp
+++ b/src/lincity-ng/Config.cpp
@@ -72,7 +72,7 @@ Config::Config()
 
     world.len(WORLD_SIDE_LEN);
     binary_mode=false;
-    seed_compression=true;
+    seed_compression=false;
     carsEnabled=true;
 
     //First we load the global File which should contain
@@ -191,7 +191,7 @@ void Config::load( const std::string& filename ){
                     } else if(strcmp(name, "binarySaveGames") == 0) {
                         // binary_mode = parseBool(value, true);
                     } else if(strcmp(name, "seed_compression") == 0) {
-                        seed_compression = parseBool(value, true);
+                        // seed_compression = parseBool(value, true);
                     } else if(strcmp(name, "carsEnabled") == 0) {
                         carsEnabled = parseBool(value, true);
                     }else {
@@ -245,7 +245,7 @@ Config::save(){
         << "language=\"" << language //
         << "\" WorldSideLen=\"" << ((world.len()<50)?50:world.len())
         // << "\" binarySaveGames=\"" << (binary_mode?"yes":"no")
-        << "\" seed_compression=\"" << (seed_compression?"yes":"no")
+        // << "\" seed_compression=\"" << (seed_compression?"yes":"no")
         << "\" carsEnabled=\"" << (carsEnabled?"yes":"no")
         << "\" />\n";
     userconfig << "</configuration>\n";

--- a/src/lincity-ng/MainMenu.cpp
+++ b/src/lincity-ng/MainMenu.cpp
@@ -319,8 +319,8 @@ MainMenu::loadOptionsMenu()
         currentCheckButton->clicked.connect( makeCallback(*this, &MainMenu::optionsMenuButtonClicked));
         // currentCheckButton = getCheckButton(*optionsMenu, "BinaryMode");
         // currentCheckButton->clicked.connect( makeCallback(*this, &MainMenu::optionsMenuButtonClicked));
-        currentCheckButton = getCheckButton(*optionsMenu, "SeedMode");
-        currentCheckButton->clicked.connect( makeCallback(*this, &MainMenu::optionsMenuButtonClicked));
+        // currentCheckButton = getCheckButton(*optionsMenu, "SeedMode");
+        // currentCheckButton->clicked.connect( makeCallback(*this, &MainMenu::optionsMenuButtonClicked));
 
         Button* currentButton = getButton(*optionsMenu, "BackButton");
         currentButton->clicked.connect( makeCallback(*this, &MainMenu::optionsBackButtonClicked));
@@ -345,10 +345,10 @@ MainMenu::loadOptionsMenu()
     // {   getCheckButton(*optionsMenu, "BinaryMode")->check();}
     // else
     // {   getCheckButton(*optionsMenu, "BinaryMode")->uncheck();}
-    if (seed_compression)
-    {   getCheckButton(*optionsMenu, "SeedMode")->check();}
-    else
-    {   getCheckButton(*optionsMenu, "SeedMode")->uncheck();}
+    // if (seed_compression)
+    // {   getCheckButton(*optionsMenu, "SeedMode")->check();}
+    // else
+    // {   getCheckButton(*optionsMenu, "SeedMode")->uncheck();}
     //current background track
     musicParagraph = getParagraph( *optionsMenu, "musicParagraph");
     musicParagraph->setText(getSound()->currentTrack.title);
@@ -602,8 +602,8 @@ void MainMenu::optionsMenuButtonClicked( CheckButton* button, int ){
         changeTrack(true);
     // } else if( buttonName == "BinaryMode"){
     //     binary_mode = !binary_mode;
-    } else if( buttonName == "SeedMode"){
-        seed_compression = !seed_compression;
+    // } else if( buttonName == "SeedMode"){
+    //     seed_compression = !seed_compression;
     } else {
         std::cerr << "MainMenu::optionsMenuButtonClicked " << buttonName << " unknown Button!\n";
     }

--- a/src/lincity/engglobs.cpp
+++ b/src/lincity/engglobs.cpp
@@ -54,7 +54,7 @@ const int dxo[8] ={ -1, -1,  0,  1,  1,  1,  0, -1};
 const int dyo[8] ={  0, -1, -1, -1,  0,  1,  1,  1};
 
 bool binary_mode = false;
-bool seed_compression = true;
+bool seed_compression = false;
 //You may want to set these to false for easier debugging
 
 //These have to be decalred as extern in lintypes.h after class Construction

--- a/src/lincity/xmlloadsave.cpp
+++ b/src/lincity/xmlloadsave.cpp
@@ -246,6 +246,7 @@ int XMLloadsave::saveXMLfile(std::string xml_file_name)
     std::cout << "gz saving " << xml_file_name << " ... ";
     std::cout.flush();
     binary_mode = false; // just to make sure
+    seed_compression = false; // just to make sure
     clearXMLlibary();
     xml_file_out.str("");
     ldsv_version = XML_LOADSAVE_VERSION;


### PR DESCRIPTION
Seed saving relies on `rand` and `srand` functions to reproduce the map tiles. However, these functions are not guaranteed to reproduce the same values across different C library implementations or versions, compilers, compiler versions, or platforms.