### PR TITLE
Local physfsrwops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ endif()
 add_subdirectory(src)
 add_subdirectory(data ${CMAKE_INSTALL_APPDATADIR})
 add_subdirectory(doc)
+add_subdirectory(external)
 
 set_target_properties(lincity-ng PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_BINDIR})
 install(TARGETS lincity-ng

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(physfsrwops)

--- a/external/physfsrwops/CMakeLists.txt
+++ b/external/physfsrwops/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(physfsrwops STATIC
+  physfsrwops.c physfsrwops.h
+)
+
+target_include_directories(physfsrwops PUBLIC .)
+target_link_libraries(physfsrwops
+  PUBLIC
+  $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+  ${PHYSFS_LIBRARY}
+)
+set_target_properties(physfsrwops PROPERTIES C_INCLUDE_WHAT_YOU_USE "")

--- a/external/physfsrwops/physfsrwops.c
+++ b/external/physfsrwops/physfsrwops.c
@@ -1,0 +1,253 @@
+/*
+ * This code provides a glue layer between PhysicsFS and Simple Directmedia
+ *  Layer's (SDL) RWops i/o abstraction.
+ *
+ * License: this code is public domain. I make no warranty that it is useful,
+ *  correct, harmless, or environmentally safe.
+ *
+ * This particular file may be used however you like, including copying it
+ *  verbatim into a closed-source project, exploiting it commercially, and
+ *  removing any trace of my name from the source (although I hope you won't
+ *  do that). I welcome enhancements and corrections to this file, but I do
+ *  not require you to send me patches if you make changes. This code has
+ *  NO WARRANTY.
+ *
+ * Unless otherwise stated, the rest of PhysicsFS falls under the zlib license.
+ *  Please see LICENSE.txt in the root of the source tree.
+ *
+ * SDL 1.2 falls under the LGPL license. SDL 1.3+ is zlib, like PhysicsFS.
+ *  You can get SDL at https://www.libsdl.org/
+ *
+ *  This file was written by Ryan C. Gordon. (icculus@icculus.org).
+ */
+
+/* This works with SDL1 and SDL2. For SDL3, use physfssdl3.c */
+
+#include <stdio.h>  /* used for SEEK_SET, SEEK_CUR, SEEK_END ... */
+#include "physfsrwops.h"
+
+/* SDL's RWOPS interface changed a little in SDL 2.0... */
+#if defined(SDL_VERSION_ATLEAST)
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+#define TARGET_SDL2 1
+#endif
+#endif
+
+#if !TARGET_SDL2
+#ifndef RW_SEEK_SET
+#define RW_SEEK_SET SEEK_SET
+#endif
+#ifndef RW_SEEK_CUR
+#define RW_SEEK_CUR SEEK_CUR
+#endif
+#ifndef RW_SEEK_END
+#define RW_SEEK_END SEEK_END
+#endif
+#endif
+
+#if TARGET_SDL2
+static Sint64 SDLCALL physfsrwops_size(struct SDL_RWops *rw)
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    return (Sint64) PHYSFS_fileLength(handle);
+} /* physfsrwops_size */
+#endif
+
+
+#if TARGET_SDL2
+static Sint64 SDLCALL physfsrwops_seek(struct SDL_RWops *rw, Sint64 offset, int whence)
+#else
+static int physfsrwops_seek(SDL_RWops *rw, int offset, int whence)
+#endif
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    PHYSFS_sint64 pos = 0;
+
+    if (whence == RW_SEEK_SET)
+        pos = (PHYSFS_sint64) offset;
+
+    else if (whence == RW_SEEK_CUR)
+    {
+        const PHYSFS_sint64 current = PHYSFS_tell(handle);
+        if (current == -1)
+        {
+            SDL_SetError("Can't find position in file: %s",
+                          PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+            return -1;
+        } /* if */
+
+        if (offset == 0)  /* this is a "tell" call. We're done. */
+        {
+            #if TARGET_SDL2
+            return (Sint64) current;
+            #else
+            return (int) current;
+            #endif
+        } /* if */
+
+        pos = current + ((PHYSFS_sint64) offset);
+    } /* else if */
+
+    else if (whence == RW_SEEK_END)
+    {
+        const PHYSFS_sint64 len = PHYSFS_fileLength(handle);
+        if (len == -1)
+        {
+            SDL_SetError("Can't find end of file: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+            return -1;
+        } /* if */
+
+        pos = len + ((PHYSFS_sint64) offset);
+    } /* else if */
+
+    else
+    {
+        SDL_SetError("Invalid 'whence' parameter.");
+        return -1;
+    } /* else */
+
+    if ( pos < 0 )
+    {
+        SDL_SetError("Attempt to seek past start of file.");
+        return -1;
+    } /* if */
+    
+    if (!PHYSFS_seek(handle, (PHYSFS_uint64) pos))
+    {
+        SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+        return -1;
+    } /* if */
+
+    #if TARGET_SDL2
+    return (Sint64) pos;
+    #else
+    return (int) pos;
+    #endif
+} /* physfsrwops_seek */
+
+
+#if TARGET_SDL2
+static size_t SDLCALL physfsrwops_read(struct SDL_RWops *rw, void *ptr,
+                                       size_t size, size_t maxnum)
+#else
+static int physfsrwops_read(SDL_RWops *rw, void *ptr, int size, int maxnum)
+#endif
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    const PHYSFS_uint64 readlen = (PHYSFS_uint64) (maxnum * size);
+    const PHYSFS_sint64 rc = PHYSFS_readBytes(handle, ptr, readlen);
+    if (rc != ((PHYSFS_sint64) readlen))
+    {
+        if (!PHYSFS_eof(handle)) /* not EOF? Must be an error. */
+        {
+            SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+
+            #if TARGET_SDL2
+            return 0;
+            #else
+            return -1;
+            #endif
+        } /* if */
+    } /* if */
+
+    #if TARGET_SDL2
+    return (size_t) rc / size;
+    #else
+    return (int) rc / size;
+    #endif
+} /* physfsrwops_read */
+
+
+#if TARGET_SDL2
+static size_t SDLCALL physfsrwops_write(struct SDL_RWops *rw, const void *ptr,
+                                        size_t size, size_t num)
+#else
+static int physfsrwops_write(SDL_RWops *rw, const void *ptr, int size, int num)
+#endif
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    const PHYSFS_uint64 writelen = (PHYSFS_uint64) (num * size);
+    const PHYSFS_sint64 rc = PHYSFS_writeBytes(handle, ptr, writelen);
+    if (rc != ((PHYSFS_sint64) writelen))
+        SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+
+    #if TARGET_SDL2
+    return (size_t) rc;
+    #else
+    return (int) rc;
+    #endif
+} /* physfsrwops_write */
+
+
+static int physfsrwops_close(SDL_RWops *rw)
+{
+    PHYSFS_File *handle = (PHYSFS_File *) rw->hidden.unknown.data1;
+    if (!PHYSFS_close(handle))
+    {
+        SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+        return -1;
+    } /* if */
+
+    SDL_FreeRW(rw);
+    return 0;
+} /* physfsrwops_close */
+
+
+static SDL_RWops *create_rwops(PHYSFS_File *handle)
+{
+    SDL_RWops *retval = NULL;
+
+    if (handle == NULL)
+        SDL_SetError("PhysicsFS error: %s", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+    else
+    {
+        retval = SDL_AllocRW();
+        if (retval != NULL)
+        {
+            #if TARGET_SDL2
+            retval->size  = physfsrwops_size;
+            #endif
+            retval->seek  = physfsrwops_seek;
+            retval->read  = physfsrwops_read;
+            retval->write = physfsrwops_write;
+            retval->close = physfsrwops_close;
+            retval->hidden.unknown.data1 = handle;
+        } /* if */
+    } /* else */
+
+    return retval;
+} /* create_rwops */
+
+
+SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_File *handle)
+{
+    SDL_RWops *retval = NULL;
+    if (handle == NULL)
+        SDL_SetError("NULL pointer passed to PHYSFSRWOPS_makeRWops().");
+    else
+        retval = create_rwops(handle);
+
+    return retval;
+} /* PHYSFSRWOPS_makeRWops */
+
+
+SDL_RWops *PHYSFSRWOPS_openRead(const char *fname)
+{
+    return create_rwops(PHYSFS_openRead(fname));
+} /* PHYSFSRWOPS_openRead */
+
+
+SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname)
+{
+    return create_rwops(PHYSFS_openWrite(fname));
+} /* PHYSFSRWOPS_openWrite */
+
+
+SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname)
+{
+    return create_rwops(PHYSFS_openAppend(fname));
+} /* PHYSFSRWOPS_openAppend */
+
+
+/* end of physfsrwops.c ... */
+

--- a/external/physfsrwops/physfsrwops.h
+++ b/external/physfsrwops/physfsrwops.h
@@ -1,0 +1,91 @@
+/*
+ * This code provides a glue layer between PhysicsFS and Simple Directmedia
+ *  Layer's (SDL) RWops i/o abstraction.
+ *
+ * License: this code is public domain. I make no warranty that it is useful,
+ *  correct, harmless, or environmentally safe.
+ *
+ * This particular file may be used however you like, including copying it
+ *  verbatim into a closed-source project, exploiting it commercially, and
+ *  removing any trace of my name from the source (although I hope you won't
+ *  do that). I welcome enhancements and corrections to this file, but I do
+ *  not require you to send me patches if you make changes. This code has
+ *  NO WARRANTY.
+ *
+ * Unless otherwise stated, the rest of PhysicsFS falls under the zlib license.
+ *  Please see LICENSE.txt in the root of the source tree.
+ *
+ * SDL 1.2 falls under the LGPL license. SDL 1.3+ is zlib, like PhysicsFS.
+ *  You can get SDL at https://www.libsdl.org/
+ *
+ *  This file was written by Ryan C. Gordon. (icculus@icculus.org).
+ */
+
+/* This works with SDL1 and SDL2. For SDL3, use physfssdl3.h */
+
+#ifndef _INCLUDE_PHYSFSRWOPS_H_
+#define _INCLUDE_PHYSFSRWOPS_H_
+
+#include "physfs.h"
+#include "SDL.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Open a platform-independent filename for reading, and make it accessible
+ *  via an SDL_RWops structure. The file will be closed in PhysicsFS when the
+ *  RWops is closed. PhysicsFS should be configured to your liking before
+ *  opening files through this method.
+ *
+ *   @param filename File to open in platform-independent notation.
+ *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+ *           of the error can be gleaned from PHYSFS_getLastError().
+ */
+PHYSFS_DECL SDL_RWops *PHYSFSRWOPS_openRead(const char *fname);
+
+/**
+ * Open a platform-independent filename for writing, and make it accessible
+ *  via an SDL_RWops structure. The file will be closed in PhysicsFS when the
+ *  RWops is closed. PhysicsFS should be configured to your liking before
+ *  opening files through this method.
+ *
+ *   @param filename File to open in platform-independent notation.
+ *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+ *           of the error can be gleaned from PHYSFS_getLastError().
+ */
+PHYSFS_DECL SDL_RWops *PHYSFSRWOPS_openWrite(const char *fname);
+
+/**
+ * Open a platform-independent filename for appending, and make it accessible
+ *  via an SDL_RWops structure. The file will be closed in PhysicsFS when the
+ *  RWops is closed. PhysicsFS should be configured to your liking before
+ *  opening files through this method.
+ *
+ *   @param filename File to open in platform-independent notation.
+ *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+ *           of the error can be gleaned from PHYSFS_getLastError().
+ */
+PHYSFS_DECL SDL_RWops *PHYSFSRWOPS_openAppend(const char *fname);
+
+/**
+ * Make a SDL_RWops from an existing PhysicsFS file handle. You should
+ *  dispose of any references to the handle after successful creation of
+ *  the RWops. The actual PhysicsFS handle will be destroyed when the
+ *  RWops is closed.
+ *
+ *   @param handle a valid PhysicsFS file handle.
+ *  @return A valid SDL_RWops structure on success, NULL on error. Specifics
+ *           of the error can be gleaned from PHYSFS_getLastError().
+ */
+PHYSFS_DECL SDL_RWops *PHYSFSRWOPS_makeRWops(PHYSFS_File *handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* include-once blocker */
+
+/* end of physfsrwops.h ... */
+

--- a/src/PhysfsStream/CMakeLists.txt
+++ b/src/PhysfsStream/CMakeLists.txt
@@ -18,25 +18,4 @@ target_include_directories(physfsstream
   ${PHYSFS_INCLUDE_DIR}
 )
 
-add_library(physfsrwops STATIC)
-include(FetchContent)
-set(physfsrwops.c_SHA256 ffebf2292e426d1d6c5874b5264e837244dbe7e24b792419a518cf09c921f8bd)
-set(physfsrwops.h_SHA256 8a40e265c9506b3bf27148db3687104824f13ec167212f913aa2ecd3e57bb3bc)
-foreach(physfsrwops_file physfsrwops.c;physfsrwops.h)
-  FetchContent_Declare(${physfsrwops_file}
-    URL https://github.com/icculus/physfs/raw/74c30545031ca8cdb69b2f1ec173e77d79078093/extras/${physfsrwops_file}
-    URL_HASH SHA256=${${physfsrwops_file}_SHA256}
-    DOWNLOAD_NO_EXTRACT TRUE
-  )
-  FetchContent_MakeAvailable(${physfsrwops_file})
-  target_sources(physfsrwops PRIVATE ${${physfsrwops_file}_SOURCE_DIR}/${physfsrwops_file})
-endforeach()
-target_include_directories(physfsrwops PUBLIC ${physfsrwops.h_SOURCE_DIR})
-target_link_libraries(physfsrwops
-  PUBLIC
-  $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
-  ${PHYSFS_LIBRARY}
-)
-set_target_properties(physfsrwops PROPERTIES C_INCLUDE_WHAT_YOU_USE "")
-
 include_directories(.)


### PR DESCRIPTION
Adds physfsrwops to a new `external` directory so that it is provided within lincity-ng instead of being fetched with FetchContent.

Fixes #203