### PR TITLE
Fix lag and high CPU utilization in menus

### DIFF
--- a/CHANGELOG.d/fix-menu-lag.md
+++ b/CHANGELOG.d/fix-menu-lag.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+###### Gameplay
+
+###### User Interface
+- Fixed lag and high CPU utilization in menus.
+
+###### Internal
+
+###### Documentation / Translation

--- a/src/lincity-ng/MainMenu.cpp
+++ b/src/lincity-ng/MainMenu.cpp
@@ -1049,14 +1049,6 @@ MainMenu::run()
         currentMenu->event(Event(elapsedTime));
         lastticks = ticks;
 
-        /* We unconditionally redraw every ~100 ms as workaround for an SDL bug
-         * under Wayland, in which window resizing is not communicated to the
-         * program until it redraws the window. When this bug is no longer
-         * present, this behavior should be safe to remove */
-        if (ticks - lastRedrawTicks > 90) {
-             currentMenu->reLayout();
-        }
-
         if(currentMenu->needsRedraw()) {
             currentMenu->draw(*painter);
             painter->updateScreen();

--- a/src/lincity-ng/MainMenu.cpp
+++ b/src/lincity-ng/MainMenu.cpp
@@ -985,7 +985,6 @@ MainMenu::run()
     quitState = QUIT;
     Uint32 fpsTicks = SDL_GetTicks();
     Uint32 lastticks = fpsTicks;
-    Uint32 lastRedrawTicks = fpsTicks;
     int frame = 0;
     while(running)
     {
@@ -1052,7 +1051,6 @@ MainMenu::run()
         if(currentMenu->needsRedraw()) {
             currentMenu->draw(*painter);
             painter->updateScreen();
-            lastRedrawTicks = ticks;
         }
 
         frame++;


### PR DESCRIPTION
Removes a workaround for a bug in the Wayland backend for SDL that seems to have been fixed. The workaround was causing the screen to be redrawn when it didn't need to be.

Fixes #201