### PR TITLE
fix incorrect default window manager after exiting game screen

### DIFF
--- a/src/lincity-ng/MainMenu.cpp
+++ b/src/lincity-ng/MainMenu.cpp
@@ -935,6 +935,8 @@ MainMenu::launchGame() {
   game->run();
   state = State::MENU;
   switchMenu(mainMenu);
+  DialogBuilder::setDefaultWindowManager(dynamic_cast<WindowManager *>(
+    menu->findComponent("windowManager")));
 }
 
 /** @file lincity-ng/MainMenu.cpp */


### PR DESCRIPTION
This fixes a bug where dialogs would not show in the main menu after loading a game.