### PR TITLE
remove hack preventing libxml2 from overlinking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,6 @@ find_package(SDL2_mixer 2.0.0 REQUIRED)
 find_package(SDL2_ttf 2.0.12 REQUIRED)
 find_package(LibXml2 REQUIRED) # requires >=2.6.11
 find_package(fmt 9.0.0 REQUIRED)
-# Prevent linking unneded libraries from LibXml2. see https://gitlab.gnome.org/GNOME/libxml2/-/issues/918
-set_target_properties(LibXml2::LibXml2 PROPERTIES INTERFACE_LINK_LIBRARIES "")
 # seems libxml++ doesn't have a find module, but it provides a pkg-config
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(libXMLPlusPlus REQUIRED IMPORTED_TARGET libxml++-5.0)


### PR DESCRIPTION
As of libxml2 2.14.4, released 2025-06-16, the overlinking issue is  fixed upstream.
https://gitlab.gnome.org/GNOME/libxml2/-/issues/918 
https://gitlab.gnome.org/GNOME/libxml2/-/blob/03af724f0821ae8c0fb819c71bfbf95fe9822c9e/NEWS#L26