### PR TITLE
fix strange texture sampling by rounding texture translation

### DIFF
--- a/CHANGELOG.d/fix-image-sampling.md
+++ b/CHANGELOG.d/fix-image-sampling.md
@@ -3,7 +3,7 @@
 ###### Gameplay
 
 ###### User Interface
-- Fixed an issue causing some UI components to appear blurry.
+- Fixed an issue causing some UI components to appear distorted.
 
 ###### Internal
 

--- a/CHANGELOG.d/fix-image-sampling.md
+++ b/CHANGELOG.d/fix-image-sampling.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+###### Gameplay
+
+###### User Interface
+- Fixed an issue causing some UI components to appear blurry.
+
+###### Internal
+
+###### Documentation / Translation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ date: 2025-07-04
 - Improved terrain/ecology generation algorithms.
 
 ###### User Interface
+- Fixed grid-lines appearing on the map.
 - Fixed duplicate click events in the new-game menu.
 - Added warning dialogs when a construction cannot be built.
 - Reworded most in-game pop-up dialogs.

--- a/src/gui/Image.cpp
+++ b/src/gui/Image.cpp
@@ -127,12 +127,11 @@ Image::resize(float width, float height)
 }
 
 void
-Image::draw(Painter& painter)
-{
-    if(width != texture->getWidth() || height != texture->getHeight())
-        painter.drawStretchTexture(texture, Rect2D(0, 0, width, height));
-    else
-        painter.drawTexture(texture, Vector2(0, 0));
+Image::draw(Painter& painter) {
+  if(flags & FLAG_RESIZABLE)
+    painter.drawStretchTexture(texture, Rect2D(0, 0, width, height));
+  else
+    painter.drawTexture(texture, Vector2(0, 0));
 }
 
 std::string Image::getFilename() const

--- a/src/gui/PainterSDL/PainterSDL.cpp
+++ b/src/gui/PainterSDL/PainterSDL.cpp
@@ -57,8 +57,21 @@ PainterSDL::~PainterSDL() { }
 
 void
 PainterSDL::drawTexture(const Texture *texture, Vector2 pos) {
-  Vector2 size((float)texture->getWidth(), (float)texture->getHeight());
-  drawStretchTexture(texture, Rect2D(pos, pos + size));
+  assert(texture);
+  assert(typeid(*texture) == typeid(TextureSDL));
+  const TextureSDL *textureSDL = static_cast<const TextureSDL *>(texture);
+
+  // We need to round the screen position to avoid sampling on pixel boundaries.
+  // Really, we only need to do this when NEAREST sampling is used.
+  Vector2 screenpos = transform.apply(pos);
+  SDL_FRect drect = {
+    .x = std::round(screenpos.x),
+    .y = std::round(screenpos.y),
+    .w = (float)texture->getWidth(),
+    .h = (float)texture->getHeight(),
+  };
+
+  HANDLE_ERR(SDL_RenderCopyF(renderer, textureSDL->tx, NULL, &drect));
 }
 
 void


### PR DESCRIPTION
It seems the GPU cannot be trusted with rounding floats with a fractional part close to 0.5. This PR rounds the absolute position of textures when they are not being stretched.

fixes #276