### PR TITLE
CMake option tweaks and additions

### DIFF
--- a/CHANGELOG.d/version-suffix-override.md
+++ b/CHANGELOG.d/version-suffix-override.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+###### Gameplay
+
+###### User Interface
+
+###### Internal
+- Added a CMake option `LINCITYNG_VERSION_SUFFIX` to allow overriding the version suffix. This is mostly useful for packaging, especially when building from a source tarball.
+
+###### Documentation / Translation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,17 @@ find_program(INCLUDE_WHAT_YOU_USE NAMES include-what-you-use)
 
 
 ### compute the LinCity-NG version
-git_describe_working_tree(FULL_PROJECT_VERSION --match lincity-ng-*)
-if(FULL_PROJECT_VERSION)
-	string(SUBSTRING ${FULL_PROJECT_VERSION} 11 -1 FULL_PROJECT_VERSION)
+set(LINCITYNG_VERSION_SUFFIX "" CACHE STRING "Custom version suffix to use; mostly useful for downstream packaging.")
+
+if (DEFINED LINCITYNG_VERSION_SUFFIX AND NOT (LINCITYNG_VERSION_SUFFIX STREQUAL ""))
+	set(FULL_PROJECT_VERSION "${PROJECT_VERSION}-${LINCITYNG_VERSION_SUFFIX}")
 else()
-	set(FULL_PROJECT_VERSION ${PROJECT_VERSION}-unknown)
+	git_describe_working_tree(FULL_PROJECT_VERSION --match lincity-ng-*)
+	if(FULL_PROJECT_VERSION)
+		string(SUBSTRING ${FULL_PROJECT_VERSION} 11 -1 FULL_PROJECT_VERSION)
+	else()
+		set(FULL_PROJECT_VERSION "${PROJECT_VERSION}-unknown")
+	endif()
 endif()
 set(BUILD_TYPE_RELEASE "")
 set(BUILD_TYPE_MINSIZEREL "")

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ cmake --build build --parallel --target package
 ```
 
 #### CMAKE_BUILD_TYPE
+
 The `-DCMAKE_BUILD_TYPE=<build-type>` option at configure time selects which
 debug features and optimization level to use. Values are case-insensitive.
 
@@ -131,6 +132,14 @@ Allowed values are:
 - Specifying any other build type not listed above will prevent
   per-configuration build flags from being used. This may be useful when
   supplying flags via `CMAKE_<LANG>_FLAGS`.
+
+#### LINCITYNG_VERSION_SUFFIX
+
+The `-DLINCITYNG_VERSION_SUFFIX=<suffix>` configure time option is provided
+for packagers to allow marking builds as coming from a specific source. It's
+especially useful when building from a source tarball or with custom patches to
+avoid an `unknown` or `dirty` suffix.
+
 
 ### Running
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -1,6 +1,6 @@
-set(DISABLE_GL_MODE ON CACHE BOOL "disables GL video mode")
+set(LINCITYNG_DISABLE_GL_MODE ON CACHE BOOL "Disable direct OpenGL renderer.")
 
-if(NOT DISABLE_GL_MODE)
+if(NOT LINCITYNG_DISABLE_GL_MODE)
 	find_package(OpenGL REQUIRED)
 endif()
 
@@ -90,7 +90,7 @@ add_library(lincity_gui  STATIC
 		PainterSDL/TextureManagerSDL.hpp
 )
 
-if(NOT DISABLE_GL_MODE)
+if(NOT LINCITYNG_DISABLE_GL_MODE)
 	target_sources(lincity_gui PRIVATE
 		PainterGL/PainterGL.cpp
 		PainterGL/PainterGL.hpp
@@ -101,7 +101,7 @@ if(NOT DISABLE_GL_MODE)
 	)
 endif()
 
-if(DISABLE_GL_MODE)
+if(LINCITYNG_DISABLE_GL_MODE)
 	target_compile_definitions(lincity_gui PUBLIC DISABLE_GL_MODE)
 endif()
 
@@ -115,7 +115,7 @@ target_link_libraries(lincity_gui
 		PRIVATE
 		tinygettext
 )
-if(NOT DISABLE_GL_MODE)
+if(NOT LINCITYNG_DISABLE_GL_MODE)
 	target_link_libraries(lincity_gui PUBLIC OpenGL::GL)
 endif()
 


### PR DESCRIPTION
* Add an option to override the version suffix as discussed in #277.
* Rename `DISABLE_GL_MODE` to `LINCITYNG_DISABLE_GL_MODE` on CMake side so that LinCity-NG specific options have a common prefix.