### PR TITLE
Use presice scrolling where applicable

### DIFF
--- a/CHANGELOG.d/precise-scrolling.md
+++ b/CHANGELOG.d/precise-scrolling.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+###### Gameplay
+
+###### User Interface
+- Added smooth scrolling support for devices where it is available, e.g. touchpads.
+
+###### Internal
+
+###### Documentation / Translation

--- a/src/gui/Event.cpp
+++ b/src/gui/Event.cpp
@@ -52,6 +52,7 @@ Event::Event(SDL_Event& event)
         case SDL_MOUSEWHEEL:
             type = MOUSEWHEEL;
             scrolly = event.wheel.y;
+            scrolly_precise = event.wheel.preciseY;
             #if SDL_VERSION_ATLEAST(2,26,0)
             mousepos = Vector2(event.wheel.mouseX, event.wheel.mouseY);
             #else

--- a/src/gui/Event.hpp
+++ b/src/gui/Event.hpp
@@ -68,6 +68,8 @@ public:
     Vector2 mousemove;
     /// amount scrolled (vertically) by mouse
     int scrolly;
+    /// amount scrolled (vertically) by mouse; can be non-integer
+    float scrolly_precise;
     /// number of the mousebutton that has been pressed
     int mousebutton;
     /// mouse button state (can be decoded with SDL_BUTTON macros)

--- a/src/gui/ScrollView.cpp
+++ b/src/gui/ScrollView.cpp
@@ -162,7 +162,7 @@ ScrollView::event(const Event& event)
             return;
         }
         float val = - contents().getPos().y;
-        val -= event.scrolly * 20;
+        val -= event.scrolly_precise * 20;
         if(val < scrollBarComp->getRangeMin())
             val = scrollBarComp->getRangeMin();
         if(val > scrollBarComp->getRangeMax())


### PR DESCRIPTION
This works really nicely with my touchpad. It was added in SDL2 2.18.0, so no need for a version check.

For now, a complete replacement isn't done as other places rely on it working as an integer accumulator - FWIW, SDL3 dropped that, so accumulation will have to be done manually when migrating there.