### PR TITLE
Smoothness improvements, especially on VRR displays

### DIFF
--- a/src/gui/Component.cpp
+++ b/src/gui/Component.cpp
@@ -204,6 +204,12 @@ Component::setDirty(const Rect2D& rect)
         parent->setChildDirty(this, rect);
 }
 
+void
+Component::requestFastNextFrame() {
+    if(parent)
+        parent->requestFastNextFrame();
+}
+
 Child&
 Component::findChild(Component* component)
 {

--- a/src/gui/Component.hpp
+++ b/src/gui/Component.hpp
@@ -151,6 +151,13 @@ protected:
     virtual void setDirty(const Rect2D& area);
 
     /**
+     * Schedule next frame to happen early and be a GUI frame.
+     * Useful for smooth animations that are not directly tied to an event,
+     * such as scrolling by holding a button.
+     */
+    virtual void requestFastNextFrame();
+
+    /**
      * Used to parse attributes (from an xml stream for example). Currently
      * parses only the name attribute.
      * @return True if the attribute has been used, false else.

--- a/src/gui/Desktop.cpp
+++ b/src/gui/Desktop.cpp
@@ -104,7 +104,8 @@ Desktop::draw(Painter& painter)
             SDL_SetCursor(cursor);
     }
     dirtyRectangles.clear();
-    force_redraw = false;
+    force_redraw = force_redraw_next_frame;
+    force_redraw_next_frame = false;
 }
 
 bool
@@ -220,6 +221,11 @@ Desktop::setDirty(const Rect2D& rect)
     dirtyRectangles.push_back(rect);
 
     Component::setDirty(rect);
+}
+
+void
+Desktop::requestFastNextFrame() {
+    force_redraw_next_frame = true;
 }
 
 /** @file gui/Desktop.cpp */

--- a/src/gui/Desktop.cpp
+++ b/src/gui/Desktop.cpp
@@ -32,6 +32,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <string>               // for char_traits, basic_string, operator<<
 
 #include "Child.hpp"            // for Childs, Child
+#include "Event.hpp"            // for Event
 #include "ComponentLoader.hpp"  // for createComponent
 #include "Style.hpp"            // for parseStyleDef
 #include "XmlReader.hpp"        // for XmlReader
@@ -81,24 +82,29 @@ Desktop::parse(XmlReader& reader)
 void
 Desktop::event(const Event& event)
 {
+    if (event.type == Event::MOUSEMOTION) {
+        // This is required for smooth mouse motion on VRR screens
+        force_redraw = true;
+    }
     Component::event(event);
 }
 
 bool
 Desktop::needsRedraw() const
 {
-    return dirtyRectangles.size() > 0;
+    return force_redraw || dirtyRectangles.size() > 0;
 }
 
 void
 Desktop::draw(Painter& painter)
 {
-    if(dirtyRectangles.size() > 0) {
+    if(needsRedraw()) {
         Component::draw(painter);
         if(cursor != SDL_GetCursor())
             SDL_SetCursor(cursor);
     }
     dirtyRectangles.clear();
+    force_redraw = false;
 }
 
 bool

--- a/src/gui/Desktop.hpp
+++ b/src/gui/Desktop.hpp
@@ -62,12 +62,14 @@ public:
 
 protected:
     void setDirty(const Rect2D& rect);
+    void requestFastNextFrame();
 
 private:
 
     typedef std::vector<Rect2D> DirtyRectangles;
     DirtyRectangles dirtyRectangles;
     bool force_redraw = false;
+    bool force_redraw_next_frame = false;
 
     SDL_Cursor *cursor;
     Component *cursorOwner;

--- a/src/gui/Desktop.hpp
+++ b/src/gui/Desktop.hpp
@@ -67,6 +67,7 @@ private:
 
     typedef std::vector<Rect2D> DirtyRectangles;
     DirtyRectangles dirtyRectangles;
+    bool force_redraw = false;
 
     SDL_Cursor *cursor;
     Component *cursorOwner;

--- a/src/gui/PainterSDL/PainterSDL.cpp
+++ b/src/gui/PainterSDL/PainterSDL.cpp
@@ -51,6 +51,7 @@ PainterSDL::PainterSDL(SDL_Renderer* _renderer) :
 {
   cliprectStack.push_back(CR_NONE);
   HANDLE_ERR(SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND));
+  HANDLE_ERR(SDL_RenderSetVSync(renderer, 1));
 }
 
 PainterSDL::~PainterSDL() { }

--- a/src/gui/ScrollBar.cpp
+++ b/src/gui/ScrollBar.cpp
@@ -206,6 +206,7 @@ ScrollBar::event(const Event& event)
             if(newVal != currentVal) {
                 setValue(newVal);
                 valueChanged(this, currentVal);
+                requestFastNextFrame();
             }
             break;
         }

--- a/src/lincity-ng/Game.cpp
+++ b/src/lincity-ng/Game.cpp
@@ -484,6 +484,9 @@ Game::run() {
         next_task = std::min({next_execute, next_animate, next_gui, next_fps});
         while(true) {
             if(!running) return;
+            if(desktop->needsRedraw())
+              next_task = 0;
+
             SDL_Event event;
             int event_timeout = next_task - SDL_GetTicks();
             if(event_timeout < 0) event_timeout = 0;
@@ -576,16 +579,13 @@ Game::run() {
                 default:
                     break;
             }
-
-            if(desktop->needsRedraw())
-              next_task = 0;
         }
 
         Uint32 tick = SDL_GetTicks();
         get_real_time_with(tick);
         frame++;
 
-        if(tick >= next_gui) { // gui update
+        if(tick >= next_gui || desktop->needsRedraw()) { // gui update
             // fire update event
             gui->event(Event((tick - prev_gui) / 1000.0f));
 

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -603,6 +603,7 @@ void GameView::scroll(float elapsedTime)
 
     viewportUpdated();
     setDirty();
+    requestFastNextFrame();
 }
 
 bool GameView::constrainViewportPosition(bool useScrollCorrection) {


### PR DESCRIPTION
Fixes #281. With these changes LinCity-NG feels a lot nicer to play on my 144Hz VRR monitor!

More specific outline of changes:

* Enable VSync - only done for the SDL painter as the OpenGL one is apparently being phased out
* Redraw on mouse motion to ensure that pointer does not feel choppy on a VRR screen
* Introduce a `Component::requestFastNextFrame` method that basically allows components to ask the main loop to render next frame as early as possible
* Run a GUI update if we're drawing anyways

### The tricky stuff

A known ~~issue~~ *peculiar behavior* with this PR is that when moving the mouse the simulation somewhat slows down (even if it stays quite fast) on the fastest speed, as it gets limited to a single simulation frame per render frame; this previously already happened with things that triggered redrawing from the event polling loop, like dragging the map, but is a lot more obvious now, especially with render frames themselves also being capped by Vsync. I don't think it's really a *huge* problem, but there are at least few ways out of it I can think of:

#### Hard way out: Move simulation to another thread

The theoretically best solution, but also obviously the hardest one. I guess you'd want some kind of mailbox synchronization where the main thread grabs the last available state and displays it. Extremely out-of-scope.

#### Naive way out: cap the top speed and allow multiple simulation frames per frame

Much easier to code (I mean, I already made an implementation), but poses the opposite problem: now render frames might get slowed down by the simulation code. For example, rocket 98 can run about 500 simulation steps per second on my laptop, which means I have to set `SIM_DELAY_FAST` to `2` to avoid major slowdown, but this won't be constant across different hardware and different cities (an early game city runs at basically lightspeed), meaning it's not a great solution.

#### Seemingly reasonable way out?: use a high-resolution timer to find out how many simulation ticks can fit in a render frame

You can try to accurately measure how long a frame takes and try to compute for how long you can run physics frames alongside it. The problem I've ran into is that presentation time seemingly doesn't really correspond to how much free time you have left over and simulation isn't the last thing to run before presentation either. I've made a somewhat functioning prototype, but it's still prone to weird fluctuations and needs a safeguard to avoid spiraling into single-digit framerates.

Honestly? At this point I'd be happy to just let things get capped by vsync. Don't move your mouse if you want the game to go truly brrr.

P.S.: @dbear496 I remember you've mentioned reworking the main loop? If so, I guess some of these changes will conflict with that, but I think they're at least worth discussing. Also, I wonder what do you think about going the route most games handle the main loop and running it at a fixed rate at all times?