### PR TITLE
fix map overlay refresh

### DIFF
--- a/CHANGELOG.d/map-overlay-refresh.md
+++ b/CHANGELOG.d/map-overlay-refresh.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+###### Gameplay
+
+###### User Interface
+- Fixed map overlay updates not triggering re-draw.
+
+###### Internal
+
+###### Documentation / Translation

--- a/src/lincity-ng/Game.cpp
+++ b/src/lincity-ng/Game.cpp
@@ -596,6 +596,7 @@ Game::run() {
             if(world->isUpdated(World::Updatable::MAP)) {
               getGameView().setDirty();
               getGameView().setMapDirty();
+              getMiniMap().setDirty();
               getMiniMap().setMapDirty();
               world->clearUpdated(World::Updatable::MAP);
             }

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -206,6 +206,7 @@ void GameView::buttonClicked( Button* button ){
     if( name == "hideHighBuildings" ){
         hideHigh = !hideHigh;
         setDirty();
+        setMapDirty();
         return;
     }
     if( name == "showTerrainHeight" ){
@@ -941,6 +942,7 @@ void GameView::event(const Event& event)
                     hideHigh = true;
                 }
                 setDirty();
+                setMapDirty();
                 break;
             }
             //overlay MiniMap Information

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -150,10 +150,20 @@ void GameView::parse(XmlReader& reader)
     cursorSize = 0;
 
     mapOverlay = overlayNone;
-    mapMode = MiniMap::NORMAL;
     buttonsConnected = false;
     lastStatusMessage = "";
     refreshMap = true;
+}
+
+void
+GameView::setGame(Game *game) {
+  this->game = game;
+  game->getMiniMap().mapChanged.connect([this](){
+    if(mapOverlay != overlayNone) {
+      setDirty();
+      setMapDirty();
+    }
+  });
 }
 
 World&
@@ -210,6 +220,7 @@ void GameView::buttonClicked( Button* button ){
     if( name == "mapOverlay" ){
         mapOverlay = (mapOverlay + 1) % (overlayMAX + 1);
         setDirty();
+        setMapDirty();
         return;
     }
     std::cerr << "GameView::buttonClicked# Unhandled Button '" << name <<"',\n";
@@ -240,63 +251,6 @@ void GameView::readOrigin( bool redraw /* = true */ ) {
  */
 void GameView::writeOrigin() {
   getWorld().map.recentPoint = getCenter().x;
-}
-/*
- *  inform GameView about change in Mini Map Mode
- */
-void GameView::setMapMode( MiniMap::DisplayMode mMode ) {
-    switch( mMode ){
-        case MiniMap::NORMAL:
-            printStatusMessage( _("Minimap: outline map") );
-            break;
-        case MiniMap::UB40:
-            printStatusMessage( _("Minimap: unemployment") );
-            break;
-        case MiniMap::POLLUTION:
-            printStatusMessage( _("Minimap: pollution") );
-            break;
-        case MiniMap::STARVE:
-            printStatusMessage( _("Minimap: nourishments") );
-            break;
-        case MiniMap::POWER:
-            printStatusMessage( _("Minimap: power supply") );
-            break;
-        case MiniMap::FIRE:
-            printStatusMessage( _("Minimap: firedepartment cover") );
-            break;
-        case MiniMap::CRICKET:
-            printStatusMessage( _("Minimap: sport cover") );
-            break;
-        case MiniMap::HEALTH:
-            printStatusMessage( _("Minimap: medical care") );
-            break;
-        case MiniMap::COAL:
-            printStatusMessage( _("Minimap: coal deposits") );
-            break;
-        case MiniMap::TRAFFIC:
-        {
-            std::string s1 = _("Minimap: traffic density:");
-            std::string s2 = commodityNames[getMiniMap()->getStuffID()];
-            printStatusMessage( s1 + " " + s2 );
-        }
-            break;
-        case MiniMap::COMMODITIES:
-        {
-            std::string s1 = _("Minimap: commodities:");
-            std::string s2 = commodityNames[getMiniMap()->getStuffID()];
-            printStatusMessage( s1 + " " + s2 );
-        }
-            break;
-        default:
-            std::cerr << "Unknown minimap mode " << mMode<<"\n";
-    }
-    if( mapMode == mMode ){
-        return;
-    }
-    mapMode = mMode;
-    if( mapOverlay != overlayNone ){
-        setDirty();
-    }
 }
 
 /*
@@ -993,6 +947,7 @@ void GameView::event(const Event& event)
             if( event.keysym.scancode == SDL_SCANCODE_V ){
                 mapOverlay = (mapOverlay+1)%(overlayMAX+1);
                 setDirty();
+                setMapDirty();
                 break;
             }
             //Zoom
@@ -1732,6 +1687,7 @@ void GameView::showToolInfo( int number /*= 0*/ )
 /*
  * Print a Message to the StatusBar.
  */
+// TODO: this method should be moved to the Game class
 void GameView::printStatusMessage( std::string message ){
     if( message == lastStatusMessage ){
         return;

--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -74,9 +74,6 @@ public:
     //size in Tiles of marking under Cursor
     void setCursorSize( int size );
 
-    //inform GameView about change in Mini Map Mode
-    void setMapMode( MiniMap::DisplayMode mMode );
-
     //Show informations about selected Tool (and price to build several tiles)
     void showToolInfo( int number = 0 );
 
@@ -93,7 +90,7 @@ public:
     //check if tile is in city
     bool inCity( MapPoint tile );
 
-    void setGame(Game *game) { this->game = game; }
+    void setGame(Game *game);
 
     bool textures_ready;
     //bool economyGraph_open;
@@ -179,7 +176,6 @@ private:
 
     bool hideHigh, showTerrainHeight;
     int mapOverlay;
-    MiniMap::DisplayMode mapMode;
     static const int overlayNone = 0;
     static const int overlayOn = 1;
     static const int overlayOnly = 2;

--- a/src/lincity-ng/MiniMap.cpp
+++ b/src/lincity-ng/MiniMap.cpp
@@ -31,6 +31,7 @@
 #include <iostream>                         // for basic_ostream, operator<<
 #include <sstream>                          // for basic_stringstream
 #include <stdexcept>                        // for runtime_error
+#include <fmt/format.h>
 
 #include "Dialog.hpp"                       // for Dialog, ASK_COAL_SURVEY
 #include "Game.hpp"                         // for Game
@@ -158,7 +159,10 @@ MiniMap::toggleStuffID(int step)
         {   ++pos;}
         stuff_ID = commodities[pos+step];
     }
-    game->getGameView().setMapMode( mMode );
+    setDirty();
+    setMapDirty();
+    mapChanged();
+    updateStatusMessage();
 }
 
 World&
@@ -443,8 +447,10 @@ void MiniMap::mapViewChangeDisplayMode(DisplayMode newMode)
     mMode=newMode;
     //switchMapViewButton(name);
     switchView("MiniMap");
-    game->getGameView().setMapMode( mMode );
-    mFullRefresh=true;
+    setDirty();
+    setMapDirty();
+    mapChanged();
+    updateStatusMessage();
 }
 
 void MiniMap::mapViewButtonClicked(CheckButton* button, int mousebutton)
@@ -976,7 +982,7 @@ void MiniMap::event(const Event& event) {
             return;
         }
         if(!inside) { //mouse just enterd the minimap, show current mapmode
-            game->getGameView().setMapMode(mMode);
+            updateStatusMessage();
             inside = true;
         }
         return;
@@ -1014,6 +1020,52 @@ void MiniMap::event(const Event& event) {
         //moved 'm' and 'n' for pagescrolling to Gameview
     }
 */
+}
+
+void
+MiniMap::updateStatusMessage() {
+  std::string m;
+  switch(mMode) {
+  case MiniMap::NORMAL:
+    m = _("Minimap: outline map");
+    break;
+  case MiniMap::UB40:
+    m = _("Minimap: unemployment");
+    break;
+  case MiniMap::POLLUTION:
+    m = _("Minimap: pollution");
+    break;
+  case MiniMap::STARVE:
+    m = _("Minimap: nourishments");
+    break;
+  case MiniMap::POWER:
+    m = _("Minimap: power supply");
+    break;
+  case MiniMap::FIRE:
+    m = _("Minimap: firedepartment cover");
+    break;
+  case MiniMap::CRICKET:
+    m = _("Minimap: sport cover");
+    break;
+  case MiniMap::HEALTH:
+    m = _("Minimap: medical care");
+    break;
+  case MiniMap::COAL:
+    m = _("Minimap: coal deposits");
+    break;
+  case MiniMap::TRAFFIC: {
+    m = _("Minimap: traffic density");
+  } // fallthrough
+  case MiniMap::COMMODITIES: {
+    if(m.empty())
+      m = _("Minimap: commodities");
+    m = fmt::format("{}: {}", m, commodityNames[stuff_ID]);
+  } break;
+  default:
+    std::cerr << "error: unknown minimap mode: " << mMode << std::endl;
+    assert(false);
+  }
+  game->getGameView().printStatusMessage(m);
 }
 
 IMPLEMENT_COMPONENT_FACTORY(MiniMap)

--- a/src/lincity-ng/MiniMap.hpp
+++ b/src/lincity-ng/MiniMap.hpp
@@ -31,6 +31,7 @@
 #include "gui/Component.hpp"        // for Component
 #include "gui/Vector2.hpp"          // for Vector2
 #include "lincity/commodities.hpp"  // for Commodity
+#include "gui/Signal.hpp"
 
 class Button;
 class CheckButton;
@@ -70,7 +71,10 @@ public:
 
     void setGame(Game *game);
 
+    void setDirty() { Component::setDirty(); }
     void setMapDirty() { mFullRefresh = true; }
+
+    Signal<> mapChanged;
 
 private:
     void mapViewButtonClicked(CheckButton* button, int);
@@ -80,7 +84,6 @@ private:
     void scrollPageDownButtonClicked(Button* button);
     void scrollPageUpButtonClicked(Button* button);
 
-
     void switchButton(CheckButton* button, int);
     void switchMapViewButton(const std::string &pName);
 
@@ -88,6 +91,7 @@ private:
     Component *findRoot(Component *c);
 //FIXME
     Vector2 mapPointToVector(MapPoint p);
+    void updateStatusMessage();
 
     void constrainPosition();
 


### PR DESCRIPTION
Since version 2.14.0 added blitting for the game-view, changing the map overlay did not trigger a full refresh, and thus the overlay mode would appear to not change until a full refresh is triggered by something else. This fixes the issue by explicitly triggering a full refresh when the overlay mode or minimap mode changes.

fixes #295 