### PR TITLE
fix english fallback

### DIFF
--- a/CHANGELOG.d/fix-english-fallback.md
+++ b/CHANGELOG.d/fix-english-fallback.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+###### Gameplay
+
+###### User Interface
+
+###### Internal
+
+###### Documentation / Translation
+- Fixed the english fallback for help pages.

--- a/src/lincity-ng/HelpWindow.cpp
+++ b/src/lincity-ng/HelpWindow.cpp
@@ -104,7 +104,7 @@ HelpWindow::showTopic(const std::string& topic)
 std::filesystem::path
 HelpWindow::getHelpFile(const std::string& topic) {
   const std::filesystem::path helpdir = getConfig()->appDataDir.get() / "help";
-  const std::filesystem::path filename(topic + ".xml");
+  const std::filesystem::path filename = topic + ".xml";
   const std::string language = dictionaryManager->get_language();
   std::filesystem::path filepath;
 


### PR DESCRIPTION
Fixes a typo in the english fallback path for finding help files. Also adds useful information to the error message when english fallback fails.

fixes #298