### PR TITLE
fix water frontier for ports

### DIFF
--- a/src/lincity/world.cpp
+++ b/src/lincity/world.cpp
@@ -206,12 +206,16 @@ unsigned short MapTile::getTopGroup() const //group of bare land or the actual c
     {   return (reportingConstruction ? reportingConstruction->constructionGroup->group : group);}
 }
 
-unsigned short MapTile::getLowerstVisibleGroup() const
-{
-    if(!reportingConstruction || reportingConstruction->flags & FLAG_TRANSPARENT)
-    {   return group;}
-    else
-    {   return reportingConstruction->constructionGroup->group;}
+unsigned short MapTile::getLowerstVisibleGroup() const {
+  if(!reportingConstruction || reportingConstruction->flags & FLAG_TRANSPARENT)
+    return group;
+  else if(reportingConstruction->constructionGroup->group == GROUP_PORT
+    && point.x == reportingConstruction->point.x + 3
+  )
+    // The water section of a port
+    return GROUP_WATER;
+  else
+    return reportingConstruction->constructionGroup->group;
 }
 
 


### PR DESCRIPTION
Modifies `getLowerstVisibleGroup` to label the east tiles of a port as `GROUP_WATER`.

Fixes #287