### PR TITLE
fix double-free of xmlOutputBuffer with libxml2 <2.13.0

### DIFF
--- a/CHANGELOG.d/fix-xmlOutputBuffer-double-free.md
+++ b/CHANGELOG.d/fix-xmlOutputBuffer-double-free.md
@@ -1,0 +1,10 @@
+## Unreleased
+
+###### Gameplay
+
+###### User Interface
+
+###### Internal
+- Fixed a segfault when saving a game with libxml2 <2.13.0.
+
+###### Documentation / Translation

--- a/src/lincity/xmlloadsave.cpp
+++ b/src/lincity/xmlloadsave.cpp
@@ -112,19 +112,12 @@ World::save(const std::filesystem::path& filename) const {
     throw std::runtime_error("failed to create XML text writer");
   }
   std::shared_ptr<xmlTextWriter> xmlWriterCloser(xmlWriter,
-#if LIBXML_VERSION >= 21300
     [&xmlStatus](xmlTextWriterPtr xmlWriter) {
+      #if LIBXML_VERSION >= 21300
       xmlStatus = xmlTextWriterClose(xmlWriter);
+      #endif
       xmlFreeTextWriter(xmlWriter);
     }
-#else
-    [&xmlStatus, &xmlWriterBuffer](xmlTextWriterPtr xmlWriter) {
-      xmlStatus = xmlOutputBufferClose(xmlWriterBuffer);
-      if(xmlStatus < 0) xmlStatus = -xmlStatus;
-      else xmlStatus = XML_ERR_OK;
-      xmlFreeTextWriter(xmlWriter);
-    }
-#endif
   );
 
 #ifdef DEBUG


### PR DESCRIPTION
`xmlFreeTextWriter` already calls `xmlOutputBufferClose`, so calling `xmlOutputBufferClose` manually causes a segfault from double-free. This PR removes the explicit call to `xmlOutputBufferClose` to avoid the double-free. Unfortunately, this means IO errors may go unreported.

fixes #316