### PR TITLE
Use xsltproc for adding a release entry

### DIFF
--- a/contrib/add-release.xsl
+++ b/contrib/add-release.xsl
@@ -6,6 +6,15 @@
   <xsl:param name="version"/>
   <xsl:param name="date"/>
 
+  <xsl:template match="/">
+    <xsl:if test="not($version) or not($date)">
+      <xsl:message terminate="yes">ERROR: Missing a version and/or date parameter; use --stringparam to supply them.</xsl:message>
+    </xsl:if>
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
+
   <xsl:template match="@* | node()">
     <xsl:copy>
       <xsl:apply-templates select="@* | node()"/>
@@ -14,7 +23,10 @@
 
   <xsl:template match="/component/releases">
     <xsl:copy>
-      <release version="{$version}" date="{$date}"/>
+      <!-- Only insert a new release if not already present -->
+      <xsl:if test="not(release[@version=$version])">
+        <release version="{$version}" date="{$date}"/>
+      </xsl:if>
       <xsl:copy-of select="@*"/>
       <xsl:copy-of select="node()"/>
     </xsl:copy>

--- a/contrib/add-release.xsl
+++ b/contrib/add-release.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:ppl="https://github.com/lincity-ng/lincity-ng" version="1.0">
+  <xsl:output indent="yes" encoding="UTF-8"/>
+  <xsl:strip-space elements="*"/>
+
+  <xsl:param name="version"/>
+  <xsl:param name="date"/>
+
+  <xsl:template match="@* | node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="/component/releases">
+    <xsl:copy>
+      <release version="{$version}" date="{$date}"/>
+      <xsl:copy-of select="@*"/>
+      <xsl:copy-of select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/data/io.github.lincity_ng.lincity-ng.metainfo.xml
+++ b/data/io.github.lincity_ng.lincity-ng.metainfo.xml
@@ -20,7 +20,7 @@
   </developer>
   <project_license>GPL-2.0-or-later</project_license>
   <metadata_license>CC0-1.0</metadata_license>
-  <content_rating type="oars-1.1" />
+  <content_rating type="oars-1.1"/>
   <requires>
     <internet>offline-only</internet>
   </requires>

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -14,6 +14,7 @@
  7. Version bump CMakeLists.txt.
  8. Change the top header of CHANGELOG.md from "Unreleased" to "LinCity-NG x.x.x" and add the date underneath. If there are security fixes, add "[SECURITY]" to the header.
  9. Add a release tag to data/io.github.lincity_ng.lincity-ng.metainfo.xml with the date.
+    - `xsltproc --stringparam version $version --stringparam date $(date -uI) -o data/io.github.lincity_ng.lincity-ng.metainfo.xml contrib/add-release.xsl data/io.github.lincity_ng.lincity-ng.metainfo.xml`
 10. Stage changes and commit.
     - `git add .`
     - `git commit -m "version x.x.x"`


### PR DESCRIPTION
Continuation of my idea in #320, implemented with `xsltproc`. The command is quite long, but that's mostly due to long (and repeating) file names.