### PR TITLE
fix template instantiation with clang

### DIFF
--- a/src/lincity-ng/Config.cpp
+++ b/src/lincity-ng/Config.cpp
@@ -432,11 +432,6 @@ Config::printHelp(const std::string& command) {
 }
 
 
-template class Config::Option<int>;
-template class Config::Option<bool>;
-template class Config::Option<std::string>;
-template class Config::Option<std::filesystem::path>;
-
 template<typename T>
 Config::Option<T>::Option() :
   default_(std::nullopt)
@@ -491,5 +486,10 @@ validateRange(const std::optional<int>& value,
   }
   return value;
 }
+
+template class Config::Option<int>;
+template class Config::Option<bool>;
+template class Config::Option<std::string>;
+template class Config::Option<std::filesystem::path>;
 
 /** @file lincity-ng/Config.cpp */


### PR DESCRIPTION
Evidently, clang wants explicit template instantiations to come after member definitions; otherwise, it fails to link the member definitions.

fixes #328