### PR TITLE
fix errors on Windows caused by std::filesystem::path::value_type

### DIFF
--- a/src/gui/ComponentFactory.cpp
+++ b/src/gui/ComponentFactory.cpp
@@ -74,7 +74,7 @@ ImportFactory::createComponent(xmlpp::TextReader& reader) {
     missingXmlAttribute(reader, "src");
 
 
-  xmlpp::TextReader nreader(importfile);
+  xmlpp::TextReader nreader(importfile.string());
   if(!nreader.read())
     throw std::runtime_error(fmt::format("file is empty: {}", importfile));
   while(nreader.get_node_type() != xmlpp::TextReader::NodeType::Element) {

--- a/src/gui/ComponentLoader.cpp
+++ b/src/gui/ComponentLoader.cpp
@@ -80,7 +80,7 @@ createComponent(const std::string& type, xmlpp::TextReader& reader) {
 
 std::unique_ptr<Component> loadGUIFile(const std::filesystem::path& filename) {
   std::filesystem::path fullpath = getConfig()->appDataDir.get() / filename;
-  xmlpp::TextReader reader(fullpath);
+  xmlpp::TextReader reader(fullpath.string());
 
   // seek to the first XML element
   if(!reader.read())

--- a/src/gui/DialogBuilder.cpp
+++ b/src/gui/DialogBuilder.cpp
@@ -85,7 +85,7 @@ DialogBuilder::image(std::unique_ptr<Image>&& image) {
 }
 
 DialogBuilder&
-DialogBuilder::imageFile(const std::string& image) {
+DialogBuilder::imageFile(const std::filesystem::path& image) {
   if(!_image) {
     _image.reset(new Image());
   }

--- a/src/gui/DialogBuilder.hpp
+++ b/src/gui/DialogBuilder.hpp
@@ -23,6 +23,7 @@
 #include <list>        // for list
 #include <memory>
 #include <string>      // for string, basic_string
+#include <filesystem>
 
 class Document;
 class Image;
@@ -43,7 +44,7 @@ public:
   DialogBuilder& messageAddText(const std::string& content);
   DialogBuilder& messageAddTextBold(const std::string& content);
   DialogBuilder& image(std::unique_ptr<Image>&& image);
-  DialogBuilder& imageFile(const std::string& image);
+  DialogBuilder& imageFile(const std::filesystem::path& image);
   DialogBuilder& buttonSet(ButtonSet buttonSet);
   DialogBuilder& windowManager(WindowManager *windowManager);
 

--- a/src/gui/Document.cpp
+++ b/src/gui/Document.cpp
@@ -79,7 +79,7 @@ Document::parse(xmlpp::TextReader& reader) {
   reader.move_to_element();
 
   if(!srcPath.empty()) {
-    xmlpp::TextReader reader(srcPath);
+    xmlpp::TextReader reader(srcPath.string());
 
     // seek to the first XML element
     if(!reader.read())

--- a/src/gui/Image.cpp
+++ b/src/gui/Image.cpp
@@ -85,7 +85,7 @@ Image::parse(xmlpp::TextReader& reader) {
   if(filename.empty())
     missingXmlAttribute(reader, "src");
 
-  texture = texture_manager->load(filename,
+  texture = texture_manager->load(filename.string(),
     grey ? TextureManager::FILTER_GREY : TextureManager::NO_FILTER);
 
   if(width <= 0 || height <= 0) {
@@ -116,16 +116,16 @@ Image::draw(Painter& painter) {
     painter.drawTexture(texture, Vector2(0, 0));
 }
 
-std::string Image::getFilename() const
+std::filesystem::path Image::getFilename() const
 {
     return filename;
 }
 
-void Image::setFile(const std::string &pfilename)
+void Image::setFile(const std::filesystem::path &pfilename)
 {
     filename=pfilename;
     texture = 0;
-    texture = texture_manager->load(pfilename);
+    texture = texture_manager->load(pfilename.string());
 
     if(width <= 0 || height <= 0) {
       width = texture->getWidth() + 1;

--- a/src/gui/Image.hpp
+++ b/src/gui/Image.hpp
@@ -25,6 +25,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #define __IMAGE_HPP__
 
 #include <string>         // for string, basic_string
+#include <filesystem>
 
 #include "Component.hpp"  // for Component
 
@@ -47,13 +48,13 @@ public:
     void resize(float width, float height);
     void draw(Painter& painter);
 
-    std::string getFilename() const;
-    void setFile(const std::string &filename);
+    std::filesystem::path getFilename() const;
+    void setFile(const std::filesystem::path &filename);
 
 private:
     Texture* texture;
     bool tiling;
-    std::string filename;
+    std::filesystem::path filename;
 };
 
 #endif

--- a/src/lincity-ng/GameView.cpp
+++ b/src/lincity-ng/GameView.cpp
@@ -401,7 +401,7 @@ GameView::preReadImages(void) {
 
   std::filesystem::path fullpath = getConfig()->appDataDir.get() /
     "images" / "tiles" / "images.xml";
-  xmlpp::TextReader reader(fullpath);
+  xmlpp::TextReader reader(fullpath.string());
   if(!reader.read())
     throw std::runtime_error(fmt::format("file is empty: {}", fullpath));
   while(reader.get_node_type() != xmlpp::TextReader::NodeType::Element) {

--- a/src/lincity-ng/Sound.cpp
+++ b/src/lincity-ng/Sound.cpp
@@ -68,7 +68,7 @@ Sound::loadWaves() {
 
   std::filesystem::path directory = getConfig()->appDataDir.get() / "sounds";
   std::filesystem::path xmlfile = directory / "sounds.xml";
-  xmlpp::TextReader reader(xmlfile);
+  xmlpp::TextReader reader(xmlfile.string());
   if(!reader.read())
     throw std::runtime_error(fmt::format("file is empty: {}", xmlfile));
   while(reader.get_node_type() != xmlpp::TextReader::NodeType::Element) {
@@ -144,7 +144,7 @@ Sound::loadWaves() {
           resGrpVec[i]->chunks.push_back(chunk);
       }
       else {
-        std::string idName = getIdName(key);
+        std::string idName = getIdName(key.string());
         waves.insert(std::pair<std::string,MIX_Audio*>(idName, chunk));
       }
       key.clear();
@@ -176,7 +176,7 @@ void Sound::loadMusicTheme() {
       std::string("could not load music theme: " + theme));
 
   //Get the number of songs
-  xmlpp::TextReader reader(xml_name);
+  xmlpp::TextReader reader(xml_name.string());
   if(!reader.read())
     throw std::runtime_error(fmt::format("file is empty: {}", xml_name));
   while(reader.get_node_type() != xmlpp::TextReader::NodeType::Element) {


### PR DESCRIPTION
This fixes errors on Windows that were introduced in #284 due to the difference in `std::filesystem::path::value_type` between Unix and Windows. Whenever, a `std::filesystem::path` is converted to a `std::string`, the `std::filesystem::path::string()` method must be called even though the conversion is implicit for Unix targets.