### PR TITLE
use relative paths in POT files

### DIFF
--- a/data/locale/CMakeLists.txt
+++ b/data/locale/CMakeLists.txt
@@ -33,19 +33,19 @@ endif()
 
 ### .POT generation
 set(POT_FILES
-  ${CMAKE_BINARY_DIR}/src/lincity-ng/lincity-ng.pot
-  ${CMAKE_BINARY_DIR}/src/lincity/lincity_lib.pot
-  ${CMAKE_BINARY_DIR}/src/lincity/modules/lincity_lib_modules.pot
-  ${CMAKE_BINARY_DIR}/share/lincity-ng/gui/guiXml.pot
+  "${CMAKE_BINARY_DIR}/src/lincity-ng/lincity-ng.pot"
+  "${CMAKE_BINARY_DIR}/src/lincity/lincity_lib.pot"
+  "${CMAKE_BINARY_DIR}/src/lincity/modules/lincity_lib_modules.pot"
+  "${CMAKE_BINARY_DIR}/share/lincity-ng/gui/guiXml.pot"
 )
 foreach(pot ${POT_FILES})
   cmake_path(GET pot FILENAME potname)
-  list(APPEND POT_TARGETS ${potname}.target)
+  list(APPEND POT_TARGETS "${potname}.target")
 endforeach()
 add_custom_command(
   OUTPUT ${CMAKE_BINARY_DIR}/messages.pot
   COMMAND ${GETTEXT_XGETTEXT} -o ${CMAKE_BINARY_DIR}/messages.pot ${POT_FILES}
-  DEPENDS ${POT_TARGETS}
+  DEPENDS ${POT_TARGETS} ${POT_FILES}
   COMMENT "merging messages.pot"
 )
 add_custom_target(generate_pot DEPENDS ${CMAKE_BINARY_DIR}/messages.pot)

--- a/mk/cmake/modules/TranslateTarget.cmake
+++ b/mk/cmake/modules/TranslateTarget.cmake
@@ -25,17 +25,22 @@ function(translate_target target)
     cmake_path(ABSOLUTE_PATH SOURCE_PATH
       BASE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
+    cmake_path(RELATIVE_PATH SOURCE_PATH
+      BASE_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    )
     list(APPEND TARGET_SOURCES ${SOURCE_PATH})
   endforeach()
   add_custom_command(
     OUTPUT ${target}.pot
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
     COMMAND ${GETTEXT_XGETTEXT}
-      --keyword='_:1' --keyword='N_:1' -o ${target}.pot ${TARGET_SOURCES}
-    DEPENDS ${TARGET_SOURCES}
+      --keyword='_:1' --keyword='N_:1'
+      -o "${CMAKE_CURRENT_BINARY_DIR}/${target}.pot" ${TARGET_SOURCES}
+    DEPENDS ${TARGET_SOURCES_REL}
     COMMENT "generating ${target}.pot"
   )
   add_custom_target(${target}.pot.target
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${target}.pot
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${target}.pot"
   )
 endfunction(translate_target)
 
@@ -45,15 +50,22 @@ function(translate_target_xml target its)
     cmake_path(ABSOLUTE_PATH SOURCE_PATH
       BASE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
+    cmake_path(RELATIVE_PATH SOURCE_PATH
+      BASE_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    )
     list(APPEND TARGET_SOURCES ${SOURCE_PATH})
   endforeach()
   add_custom_command(
     OUTPUT ${target}.pot
-    COMMAND ${GETTEXT_XGETTEXT} --its=${its} -o ${target}.pot ${TARGET_SOURCES}
-    DEPENDS ${TARGET_SOURCES} ${its}
+    WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+    COMMAND ${GETTEXT_XGETTEXT}
+      --its=${its}
+      -o "${CMAKE_CURRENT_BINARY_DIR}/${target}.pot"
+      ${TARGET_SOURCES}
+    DEPENDS ${TARGET_SOURCES_REL} ${its}
     COMMENT "generating ${target}.pot"
   )
   add_custom_target(${target}.pot.target
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${target}.pot
+    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${target}.pot"
   )
 endfunction(translate_target_xml)


### PR DESCRIPTION
Avoids using absolute paths in POT files. Also fixes an issue where messages.pot may not be re-built when sources are changed.