### PR TITLE
Fix disabled CheckButtons firing click events

### DIFF
--- a/src/gui/CheckButton.cpp
+++ b/src/gui/CheckButton.cpp
@@ -230,17 +230,19 @@ CheckButton::event(const Event& event) {
       break;
     mpressed = false;
     if(event.inside) {
-      if(event.mousebutton == SDL_BUTTON_LEFT && !mdisabled) {
-        if(mchecked && autoUncheck) {
-          mchecked = false;
-          unchecked(this);
+      if(!mdisabled) {
+        if(event.mousebutton == SDL_BUTTON_LEFT) {
+          if(mchecked && autoUncheck) {
+            mchecked = false;
+            unchecked(this);
+          }
+          else if(!mchecked && autoCheck) {
+            mchecked = true;
+            checked(this);
+          }
         }
-        else if(!mchecked && autoCheck) {
-          mchecked = true;
-          checked(this);
-        }
+        clicked(this, event.mousebutton);
       }
-      clicked(this, event.mousebutton);
     }
     released(this, event.mousebutton);
     setDirty();


### PR DESCRIPTION
Previously, the `clicked()` signal in `CheckButton::event()` was called outside of the `!mdisabled` guard during a MOUSEBUTTONUP event. This caused disabled check buttons to still emit click events and trigger unwanted actions in the game logic.

This commit moves the `clicked()` emission inside the `!mdisabled` condition so that disabled UI elements correctly ignore mouse clicks.

This fix was generated by Gemini AI Pro 3.1