### PR TITLE
Fix arid leaking across tiles in setup_land()

### DIFF
--- a/src/lincity/init_game.cpp
+++ b/src/lincity/init_game.cpp
@@ -204,6 +204,7 @@ void setup_land(Map& map, int global_aridity, bool without_trees) {
     d2w_min = r * r;
     alt0 = *water(p.x,p.y);
 
+    arid = global_aridity; // reset per tile; must not carry over from the previous tile
     /* near river lower aridity */
     if (arid > 0) {
       if (d2w_min < 5)


### PR DESCRIPTION
`arid` was declared once, before the per-tile loop that assigns ecology (desert/forest/water) to each land tile, and was only ever lowered when a tile turned out to be close to a river -- never reset back to global_aridity for tiles that aren't.

Since the loop scans tiles in row-major order, the first near-river tile encountered would drag `arid` down for every tile after it in the scan, including ones nowhere near water. Ecology generation ended up depending on scan order instead of each tile's own distance to water, which could skew desert/forest placement, especially on high-aridity maps.

Reset `arid` to global_aridity at the start of each tile's computation so the "near river lowers aridity" adjustment reflects only that tile's own distance, matching what the surrounding comment already says it should do.

This fix was generated by Claude Sonnet 5.