### PR TITLE
Fix inside/edge test in diamond-square square step

### DIFF
--- a/src/lincity/init_game.cpp
+++ b/src/lincity/init_game.cpp
@@ -478,7 +478,7 @@ static void new_setup_river_ground(Map& map,
                 if(!*f1(endx, midy))
                 {
                     float right_center;
-                    if ( l < k-1) //inside map
+                    if (l < n-1) //inside map
                     {                                                         //to the right             //middle
                         right_center = (right_top + right_down + center + *f1(midx + size, midy))/4;
                     }
@@ -493,7 +493,7 @@ static void new_setup_river_ground(Map& map,
                 if (!*f1(midx, endy))
                 {
                     float down_center;
-                    if (m < k-1) //inside map
+                    if (m < n-1) //inside map
                     {                                                         //middle            // downwards
                         down_center = (left_down + right_down + center + *f1(midx, midy + size ))/4;
                     }


### PR DESCRIPTION
In the square step of new_setup_river_ground(), whether a block is "inside the map" (has a real neighbor to average with) or "at the edge" (must wrap around) was decided by comparing the block index (l or m, ranging over [0, n)) against k-1, the outer loop's iteration counter.

n and k are not the same quantity: n doubles at the end of each iteration, so during iteration k, n == 2^(k-1). That only equals k for k = 1 and k = 2; from k = 3 on, n grows much faster than k, so n-1 != k-1. The intended cutoff is n-1, the true last block index for this iteration, not k-1.

The effect: for k >= 3, blocks that do have a genuine right/down neighbor get misclassified as edge blocks and wrap around to sample from the opposite side of the array instead of averaging with that neighbor. Since NLOOP reaches 5+ for ordinary map sizes, most iterations of the algorithm hit this, which would show up as incorrect seams or repeated patterns in generated terrain.

Compare against n-1 instead of k-1 for both the right-edge and down-edge checks.

This fix was generated by Claude Sonnet 5.