### PR TITLE
Improve input validation to fix #366

### DIFF
--- a/CHANGELOG.d/fix-negative-map-size.md
+++ b/CHANGELOG.d/fix-negative-map-size.md
@@ -1,0 +1,11 @@
+## Unreleased
+
+###### Gameplay
+
+###### User Interface
+- Fixed a bug where users could pick a negative map size in settings
+
+###### Internal
+- Added the constants worldSizeMin and worldSizeMax in Config.hpp 
+
+###### Documentation / Translation

--- a/data/gui/creditslist.xml
+++ b/data/gui/creditslist.xml
@@ -42,6 +42,10 @@
     <span style="year">2005 - 2007</span>
   </p>
   <p style="person">
+    Justus Fischer
+    <span style="year">2026</span>
+  </p>
+  <p style="person">
     Edu Garcia
     <span style="year">2023</span>
   </p>

--- a/src/lincity-ng/Config.cpp
+++ b/src/lincity-ng/Config.cpp
@@ -221,7 +221,8 @@ void Config::load(std::filesystem::path configFile) {
           language.config = xmlParseConfig<std::string>(xml_val);
         else if(xml_tag == "WorldSideLen")
           worldSize.config =
-            validateRange(xmlParseConfig<int>(xml_val), 50, 10000);
+            validateRange(xmlParseConfig<int>(
+              xml_val), Config::worldSizeMin, Config::worldSizeMax);
         else if(xml_tag == "carsEnabled")
           carsEnabled.config = xmlParseConfig<bool>(xml_val);
         else if(xml_tag == "appDataDir")

--- a/src/lincity-ng/Config.hpp
+++ b/src/lincity-ng/Config.hpp
@@ -73,6 +73,8 @@ public:
   Option<std::string> language;
   Option<std::string> musicTheme;
 
+  static constexpr int worldSizeMin = 50;
+  static constexpr int worldSizeMax = 10000;
   Option<int> worldSize;
 
   void load(std::filesystem::path configPath = std::filesystem::path());

--- a/src/lincity-ng/MainMenu.cpp
+++ b/src/lincity-ng/MainMenu.cpp
@@ -570,7 +570,9 @@ void MainMenu::changeResolution(bool next) {
 
 void
 MainMenu::changeWorldLen(bool next) {
-  getConfig()->worldSize.session = getConfig()->worldSize.get() + (next?25:-25);
+  getConfig()->worldSize.session = std::clamp<int>(
+    (getConfig()->worldSize.get() + (
+      next ? 25 : -25)), Config::worldSizeMin, Config::worldSizeMax);
   getParagraph(*optionsMenu, "WorldLenParagraph")->setText(
     std::to_string(getConfig()->worldSize.get()));
 }


### PR DESCRIPTION
@Wuzzy2 found a bug where the user can change the map size to 0 or a negative size, which caused the game to crash.

While `src/lincity-ng/Config.cpp` (line 223) attempts to protect the game from negative values, it does not fully prevent invalid inputs via the UI. Therefore, `std::clamp` has been implemented in `src/lincity-ng/MainMenu.cpp` (line 571), which handles the logic for the buttons that set the map size. This now protects the game from crashes by using the min and max limits from `Config.cpp` (line 224).
To simplify the code, the constants `worldSizeMin` and `worldSizeMax` have been added to `src/lincity-ng/Config.hpp` (lines 76 and 77) to replace the values that were previously written directly into `Config.cpp`.

Now it is impossible for the user to select a map size lower than 50.

Fixes #366