### PR TITLE
Make GameView's cross-thread loader flags atomic

### DIFF
--- a/src/lincity-ng/GameView.hpp
+++ b/src/lincity-ng/GameView.hpp
@@ -24,6 +24,7 @@
 #define __GAMEVIEW_HPP__
 
 #include <SDL3/SDL.h>             // for Uint32, SDL_Surface, SDL_Thread
+#include <atomic>                 // for atomic
 #include <filesystem>             // for path
 #include <memory>                 // for unique_ptr
 #include <string>                 // for string, basic_string
@@ -93,9 +94,9 @@ public:
 
     void setGame(Game *game);
 
-    bool textures_ready;
+    std::atomic<bool> textures_ready;
     //bool economyGraph_open;
-    int remaining_images;
+    std::atomic<int> remaining_images;
 
 private:
     void connectButtons();
@@ -156,7 +157,7 @@ private:
     //SDL_mutex* mTextures;
     //SDL_mutex* mThreadRunning;
     SDL_Thread* loaderThread;
-    bool stopThread;
+    std::atomic<bool> stopThread;
 
     MapPoint tileUnderMouse;
     bool mouseInGameView;


### PR DESCRIPTION
stopThread and remaining_images are written from the loader thread (preReadImages increments remaining_images; gameViewThread's poll loop reads both) and also written from the main thread (fetchTextures and drawTexture decrement remaining_images as textures get created; ~GameView sets stopThread on shutdown). textures_ready is written on the loader thread and is public, so it's presumably read from the main thread as well. None of the three had any synchronization -- the header's SDL_mutex* mTextures / mThreadRunning members that once likely protected this are both commented out.

Plain bool/int shared across threads without synchronization is a data race under the C++ memory model, regardless of whether it happens to behave on any given compiler/platform. The failure mode if it doesn't is the loader thread's poll loop never observing an update to stopThread or remaining_images -- in the worst case, the destructor's SDL_WaitThread call hangs waiting for a thread that will never exit.

Switch all three to std::atomic. Their usage here is simple flag/ counter semantics (read, write, increment, decrement) with no compare-and-swap or custom ordering needs, so default sequentially consistent std::atomic is the right tool without reaching for a mutex. Every existing read/write site in GameView.cpp already uses operators std::atomic supports unchanged (=, !, !=, ++, --), so no .cpp changes are needed.

This fix was generated by Claude Sonnet 5.