### PR TITLE
fix translation of text spans with leading/trailing whitespace

### DIFF
--- a/CHANGELOG.d/fix-space-translation.md
+++ b/CHANGELOG.d/fix-space-translation.md
@@ -1,0 +1,4 @@
+## Unreleased
+
+###### Documentation / Translation
+- Fixed an issue preventing pbar labels from being translated properly.

--- a/src/gui/Paragraph.cpp
+++ b/src/gui/Paragraph.cpp
@@ -94,7 +94,19 @@ Paragraph::commit_changes(
 ) {
   if(!currentspan) return;
   if(translatable) {
-    currentspan->text = _(currentspan->text);
+    std::string& text = currentspan->text;
+    if(text.length() >= 2) {
+      bool frontspace = text.front() == ' ';
+      bool backspace = text.back() == ' ';
+      if(frontspace) text.erase(0, 1);
+      if(backspace) text.pop_back();
+      text = _(text);
+      if(frontspace) text.insert(0, " ");
+      if(backspace) text.push_back(' ');
+    }
+    else {
+      text = _(text);
+    }
   }
   textspans.push_back(std::unique_ptr<TextSpan>(currentspan.release()));
 }


### PR DESCRIPTION
Leading/trailing whitespace was inhibiting translation of some paragraphs (particularly the pbars). This PR strips such leading/trailing whitespace before calling gettext and reinserts the whitespace to the result.