### PR TITLE
Fix key name in German park help text

### DIFF
--- a/data/help/de/park.xml
+++ b/data/help/de/park.xml
@@ -12,7 +12,7 @@
     entsprechend bauen.</p>
         <p style="hp">Parks sind viel effektiver als Wälder (Köhlereien) oder Bauernhöfe,
         aber benötigen Grundwasser, sie können also nur auf Grünflächen gebaut werden.</p>
-        <p style="hp">Tipp: Halten Sie die Taste »W« gedrückt, während Sie einen Park
+        <p style="hp">Tipp: Halten Sie die Taste »k« gedrückt, während Sie einen Park
         bauen, um einen kleinen Teich zu erhalten.</p>
 	
 	<p style="hp">Das ist ein Park</p>


### PR DESCRIPTION
The key name mentioned in the German park help text was not updated, so this PR fixes it. The actual key you need to press is "k", not "W".

See also: #378, #364